### PR TITLE
Upgrade to htmlentities 4.3.4.  Fixes #3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
     geoip-c (0.9.1)
     gherkin (2.12.2)
       multi_json (~> 1.3)
-    htmlentities (4.3.2)
+    htmlentities (4.3.4)
     mini_portile (0.6.0)
     multi_json (1.10.1)
     multi_test (0.1.1)
@@ -57,3 +57,6 @@ DEPENDENCIES
   oj
   recog (>= 2.0)
   rspec (~> 3.1.0)
+
+BUNDLED WITH
+   1.10.5


### PR DESCRIPTION
As pointed out in #2, the fix is to just upgrade htmlentities.  Fixes #3.

Before:

```
$  echo 8.8.8.8 | bin/dap + lines + geo_ip line + json
/home/jhart/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/htmlentities-4.3.2/lib/htmlentities/mappings/expanded.rb:465: warning: duplicated key at line 466 ignored: "inodot"
{"line":"8.8.8.8"}
```

After

```
$  echo 8.8.8.8 | bin/dap + lines + geo_ip line + json 
{"line":"8.8.8.8"}
```

Depends on https://github.com/rapid7/dap/pull/8