### PR TITLE
Bump recog to latest

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ GEM
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     oj (2.10.2)
-    recog (2.0.14)
+    recog (2.0.15)
       nokogiri
     rspec (3.1.0)
       rspec-core (~> 3.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ GEM
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     oj (2.10.2)
-    recog (2.0.15)
+    recog (2.0.14)
       nokogiri
     rspec (3.1.0)
       rspec-core (~> 3.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,14 +21,14 @@ GEM
     gherkin (2.12.2)
       multi_json (~> 1.3)
     htmlentities (4.3.2)
-    mini_portile (0.6.0)
+    mini_portile (0.6.2)
     multi_json (1.10.1)
     multi_test (0.1.1)
     net-dns (0.8.0)
-    nokogiri (1.6.3.1)
-      mini_portile (= 0.6.0)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
     oj (2.10.2)
-    recog (2.0.2)
+    recog (2.0.15)
       nokogiri
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
@@ -56,3 +56,6 @@ DEPENDENCIES
   oj
   recog (>= 2.0)
   rspec (~> 3.1.0)
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
2.0.2 is somewhat old and there have been enough fingerprint improvements since then to warrant this change.

In the future, we may decide to not pin recog like this.

Depends on https://github.com/rapid7/dap/pull/8