### PR TITLE
DAP: Fix LDAP parsing bugs, increase RFC coverage

### DIFF
--- a/lib/dap/filter/ldap.rb
+++ b/lib/dap/filter/ldap.rb
@@ -36,9 +36,11 @@ class FilterDecodeLdapSearchResult
       begin
         elem_decoded = OpenSSL::ASN1.decode(element)
       rescue Exception => e
-        err_msg = 'FilterDecodeLdapSearchResult - Unable to decode ANS1 element'
+        err_msg = 'FilterDecodeLdapSearchResult - Unable to decode ANS.1 element'
         $stderr.puts "#{err_msg}: #{e}"
         $stderr.puts e.backtrace
+        $stderr.puts "\nElement:\n#{element}\n"
+        $stderr.puts "\nElement hex:\n#{element.unpack('H*')}\n\n"
         info['Error'] = { 'errorMessage' => err_msg }
         next
       end

--- a/lib/dap/filter/ldap.rb
+++ b/lib/dap/filter/ldap.rb
@@ -36,11 +36,11 @@ class FilterDecodeLdapSearchResult
       begin
         elem_decoded = OpenSSL::ASN1.decode(element)
       rescue Exception => e
-        err_msg = 'FilterDecodeLdapSearchResult - Unable to decode ANS.1 element'
+        err_msg = 'FilterDecodeLdapSearchResult - Unable to decode ASN.1 element'
         $stderr.puts "#{err_msg}: #{e}"
         $stderr.puts e.backtrace
-        $stderr.puts "\nElement:\n#{element}\n"
-        $stderr.puts "\nElement hex:\n#{element.unpack('H*')}\n\n"
+        $stderr.puts "Element:\n\t#{element.inspect}"
+        $stderr.puts "Element hex:\n\t#{element.unpack('H*')}\n\n"
         info['Error'] = { 'errorMessage' => err_msg }
         next
       end

--- a/lib/dap/proto/ldap.rb
+++ b/lib/dap/proto/ldap.rb
@@ -49,18 +49,15 @@ class LDAP
       len_bytes = length - 128
       return unless data.length > len_bytes + 2
 
-      if len_bytes == 1
-        length = data.byteslice(2, len_bytes).unpack('C')[0]
-      elsif len_bytes == 2
-        length = data.byteslice(2, len_bytes).unpack('S>')[0]
-      elsif len_bytes == 3
-        a, b, c = data.byteslice(2, len_bytes).unpack('CCC')
-        a = a << 16
-        b = b << 8
-        length = a + b + c
-      else
-        length = data.byteslice(2, len_bytes).unpack('L>')[0]
+      # This shouldn't happen...
+      return unless len_bytes > 0
+
+      length = 0
+      len_bytes.times do |i|
+        temp_len = data.byteslice(2 + i).unpack('C')[0]
+        length = ( length << 8 ) + temp_len
       end
+
       elem_start += len_bytes
     end
 

--- a/lib/dap/proto/ldap.rb
+++ b/lib/dap/proto/ldap.rb
@@ -4,27 +4,41 @@ class LDAP
 
   # LDAPResult element resultCode lookup
   #   Reference: https://tools.ietf.org/html/rfc4511#section-4.1.9
+  #              https://ldapwiki.willeke.com/wiki/LDAP%20Result%20Codes
   RESULT_DESC = {
     0 => 'success',
     1 => 'operationsError',
     2 => 'protocolError',
     3 => 'timeLimitExceeded',
     4 => 'sizeLimitExceeded',
+    5 => 'compareFalse',
+    6 => 'compareTrue',
     7 => 'authMethodNotSupported',
     8 => 'strongerAuthRequired',
+    9 => 'reserved',
     10 => 'referral',
     11 => 'adminLimitExceeded',
     12 => 'unavailableCriticalExtension',
     13 => 'confidentialityRequired',
     14 => 'saslBindInProgress',
+    16 => 'noSuchAttribute',
+    17 => 'undefinedAttributeType',
+    18 => 'inappropriateMatching',
+    19 => 'constraintViolation',
+    20 => 'attributeOrValueExists',
+    21 => 'invalidAttributeSyntax',
     32 => 'noSuchObject',
-    43 => 'invalidDNSyntax',
+    34 => 'invalidDNSyntax',
     48 => 'inappropriateAuthentication',
     49 => 'invalidCredentials',
     50 => 'insufficientAccessRights',
     51 => 'busy',
     52 => 'unavailable',
     53 => 'unwillingToPerform',
+    64 => 'namingViolation',
+    80 => 'other',
+    82 => 'localError (client response)',
+    94 => 'noResultsReturned (client response)',
   }
 
   #

--- a/spec/dap/filter/ldap_filter_spec.rb
+++ b/spec/dap/filter/ldap_filter_spec.rb
@@ -18,6 +18,7 @@ describe Dap::Filter::FilterDecodeLdapSearchResult do
       it 'returns expected value' do
         test_val = { 'SearchResultDone' => {
                        'resultCode' => 0,
+                       'resultDesc' => 'success',
                        'resultMatchedDN' => '',
                        'resultdiagMessage' => ''
                    },

--- a/spec/dap/proto/ldap_proto_spec.rb
+++ b/spec/dap/proto/ldap_proto_spec.rb
@@ -4,6 +4,7 @@ describe Dap::Proto::LDAP do
   describe '.decode_elem_length' do
     context 'testing lengths shorter than 128 bits' do
       data = ['301402'].pack('H*')
+
       let(:decode_len) { subject.decode_elem_length(data) }
       it 'returns a Fixnum' do
         expect(decode_len.class).to eq(::Fixnum)
@@ -15,6 +16,7 @@ describe Dap::Proto::LDAP do
 
     context 'testing lengths greater than 128 bits' do
       data = ['308400000bc102010'].pack('H*')
+
       let(:decode_len) { subject.decode_elem_length(data) }
       it 'returns a Fixnum' do
         expect(decode_len.class).to eq(::Fixnum)
@@ -24,8 +26,21 @@ describe Dap::Proto::LDAP do
       end
     end
 
+    context 'testing with 3 byte length' do
+      data = ['3083015e0802010764'].pack('H*')
+
+      let(:decode_len) { subject.decode_elem_length(data) }
+      it 'returns a Fixnum' do
+        expect(decode_len.class).to eq(::Fixnum)
+      end
+      it 'returns value correctly' do
+        expect(decode_len).to eq(89613)
+      end
+    end
+
     context 'testing invalid length' do
       data = ['308400000bc1'].pack('H*')
+
       let(:decode_len) { subject.decode_elem_length(data) }
       it 'returns nil as expected' do
         expect(decode_len).to eq(nil)
@@ -77,6 +92,44 @@ describe Dap::Proto::LDAP do
     end
   end
 
+  describe '.parse_ldapresult' do
+
+    context 'testing valid data' do
+      hex = ['300c02010765070a010004000400']
+      data = OpenSSL::ASN1.decode(hex.pack('H*'))
+
+      let(:parse_ldapresult) { subject.parse_ldapresult(data.value[1]) }
+      it 'returns Hash as expected' do
+        expect(parse_ldapresult.class).to eq(::Hash)
+      end
+
+      it 'returns results as expected' do
+        test_val = {  'resultCode' => 0,
+                      'resultDesc' => 'success',
+                      'resultMatchedDN' => '',
+                      'resultdiagMessage' => ''
+        }
+        expect(parse_ldapresult).to eq(test_val)
+      end
+    end
+
+    context 'testing invalid data' do
+      hex = ['300702010765020400']
+      data = OpenSSL::ASN1.decode(hex.pack('H*'))
+
+      let(:parse_ldapresult) { subject.parse_ldapresult(data.value[1]) }
+      it 'returns Hash as expected' do
+        expect(parse_ldapresult.class).to eq(::Hash)
+      end
+
+      it 'returns empty Hash as expected' do
+        test_val = {}
+        expect(parse_ldapresult).to eq(test_val)
+      end
+    end
+
+  end
+
   describe '.parse_messages' do
 
     context 'testing SearchResultEntry' do
@@ -115,8 +168,27 @@ describe Dap::Proto::LDAP do
       it 'returns SearchResultDone value as expected' do
         test_val = ['SearchResultDone', {
                       'resultCode' => 0,
+                      'resultDesc' => 'success',
                       'resultMatchedDN' => '',
                       'resultdiagMessage' => ''
+        }]
+        expect(parse_message).to eq(test_val)
+      end
+    end
+
+    context 'testing SearchResultDone - edge case #1' do
+      hex = ['300802010765000a0101']
+      data = OpenSSL::ASN1.decode(hex.pack('H*'))
+
+      let(:parse_message) { subject.parse_message(data) }
+      it 'returns Array as expected' do
+        expect(parse_message.class).to eq(::Array)
+      end
+
+      it 'returns operationsError as expected' do
+        test_val = ['SearchResultDone', {
+                      'resultCode' => 1,
+                      'resultDesc' => 'operationsError'
         }]
         expect(parse_message).to eq(test_val)
       end


### PR DESCRIPTION
- Fix issue dealing with 3 byte ASN.1 element length
- Improve handling of LDAPResult messages that don't appear to comply with RFC 4511
- Refactor code for the above (DRY)
- Add support for additional response types (LDAP Application codes) and optional elements in the message
- Provide plaintext resultCode in addition to the code itself
- Add additional information to StdErr to assist with debugging
- Create additional spec's to cover new code and corner cases