### PR TITLE
Filter:LDAP - Address empty seq/invalid lengths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 sudo: false
 rvm:
   - 2.3.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-cache: bundler
 sudo: false
 rvm:
   - 2.3.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,10 @@ sudo: false
 
 rvm:
   - 2.1.7
-  - 2.3.1
-
 addons:
   apt:
     packages:
     - libgeoip-dev
     - libgeoip1
     - openssl
-script:
-    - openssl version
-    - ruby -v -ropenssl -rfiddle -e 'puts Fiddle::Function.new(Fiddle.dlopen(nil)["SSLeay_version"], [Fiddle::TYPE_INT], Fiddle::TYPE_VOIDP).call(0)'
-    - bundle exec rspec spec
+script: openssl version && bundle exec rspec spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-  - 2.3.1
+  - 2.1.7
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 cache: bundler
 sudo: false
+
 rvm:
   - 2.1.7
 addons:
@@ -8,4 +9,5 @@ addons:
     packages:
     - libgeoip-dev
     - libgeoip1
-script: bundle exec rspec spec
+    - openssl
+script: openssl version && bundle exec rspec spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-  - 2.1.7
+  - 2.3.1
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: ruby
 cache: bundler
 sudo: false
 
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y openssl
+
 rvm:
   - 2.1.7
 addons:
@@ -9,5 +13,4 @@ addons:
     packages:
     - libgeoip-dev
     - libgeoip1
-    - openssl
 script: openssl version && bundle exec rspec spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: ruby
 cache: bundler
 sudo: false
 
-before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install -y openssl
-
 rvm:
   - 2.1.7
 addons:
@@ -13,4 +9,5 @@ addons:
     packages:
     - libgeoip-dev
     - libgeoip1
+    - openssl
 script: openssl version && bundle exec rspec spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,15 @@ sudo: false
 
 rvm:
   - 2.1.7
+  - 2.3.1
+
 addons:
   apt:
     packages:
     - libgeoip-dev
     - libgeoip1
     - openssl
-script: openssl version && bundle exec rspec spec
+script:
+    - openssl version
+    - ruby -v -ropenssl -rfiddle -e 'puts Fiddle::Function.new(Fiddle.dlopen(nil)["SSLeay_version"], [Fiddle::TYPE_INT], Fiddle::TYPE_VOIDP).call(0)'
+    - bundle exec rspec spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 cache: bundler
 sudo: false
-
 rvm:
   - 2.1.7
 addons:
@@ -9,5 +8,4 @@ addons:
     packages:
     - libgeoip-dev
     - libgeoip1
-    - openssl
-script: openssl version && bundle exec rspec spec
+script: bundle exec rspec spec

--- a/lib/dap/proto/ldap.rb
+++ b/lib/dap/proto/ldap.rb
@@ -166,6 +166,12 @@ class LDAP
       return [result_type, results]
     end
 
+    unless data.value && data.value.length > 1
+      result_type = 'Error'
+      results['errorMessage'] = 'parse_message: Invalid LDAP response (Empty Sequence)'
+      return [result_type, results]
+    end
+
     if data.value[1].tag == 4
       # SearchResultEntry found..
       result_type = 'SearchResultEntry'

--- a/spec/dap/proto/ldap_proto_spec.rb
+++ b/spec/dap/proto/ldap_proto_spec.rb
@@ -103,6 +103,20 @@ describe Dap::Proto::LDAP do
         expect(split_messages).to eq([])
       end
     end
+
+    context 'testing empty ASN.1 Sequence' do
+      hex = ['308400000000']
+      empty_seq = hex.pack('H*')
+
+      let(:split_messages) { subject.split_messages(empty_seq) }
+      it 'returns Array as expected' do
+        expect(split_messages.class).to eq(::Array)
+      end
+
+      it 'returns empty Array as expected' do
+        expect(split_messages).to eq([])
+      end
+    end
   end
 
   describe '.parse_ldapresult' do

--- a/spec/dap/proto/ldap_proto_spec.rb
+++ b/spec/dap/proto/ldap_proto_spec.rb
@@ -57,6 +57,8 @@ describe Dap::Proto::LDAP do
 
     data = original.pack('H*')
 
+    excessive_len = ['308480010000000000000000'].pack('H*')
+
     entry = ['3030020107642b040030273025040b6f626a656374436c6173'\
              '7331160403746f70040f4f70656e4c444150726f6f74445345']
 
@@ -88,6 +90,17 @@ describe Dap::Proto::LDAP do
       let(:split_messages) { subject.split_messages('00') }
       it 'returns Array as expected' do
         expect(split_messages.class).to eq(::Array)
+      end
+    end
+
+    context 'testing message length greater than total data length' do
+      let(:split_messages) { subject.split_messages(excessive_len) }
+      it 'returns Array as expected' do
+        expect(split_messages.class).to eq(::Array)
+      end
+
+      it 'returns empty Array as expected' do
+        expect(split_messages).to eq([])
       end
     end
   end
@@ -205,6 +218,24 @@ describe Dap::Proto::LDAP do
 
       it 'returns UnhandledTag value as expected' do
         test_val = ['UnhandledTag', { 'tagNumber' => 7 }]
+        expect(parse_message).to eq(test_val)
+      end
+    end
+
+    context 'testing empty ASN.1 Sequence' do
+      hex = ['308400000000']
+      data = OpenSSL::ASN1.decode(hex.pack('H*'))
+
+      let(:parse_message) { subject.parse_message(data) }
+      it 'returns Array as expected' do
+        expect(parse_message.class).to eq(::Array)
+      end
+
+      it 'returns error value as expected' do
+        test_val = ['Error', {
+                      'errorMessage' =>
+                        'parse_message: Invalid LDAP response (Empty Sequence)'
+        }]
         expect(parse_message).to eq(test_val)
       end
     end

--- a/spec/dap/proto/ldap_proto_spec.rb
+++ b/spec/dap/proto/ldap_proto_spec.rb
@@ -237,8 +237,8 @@ describe Dap::Proto::LDAP do
     end
 
     context 'testing empty ASN.1 Sequence' do
-      hex = ['308400000000']
-      data = OpenSSL::ASN1.decode(hex.pack('H*'))
+
+      data = OpenSSL::ASN1::Sequence.new([])
 
       let(:parse_message) { subject.parse_message(data) }
       it 'returns Array as expected' do


### PR DESCRIPTION
Add code and related spec entry to handle when the remote server returns a correctly formed but empty ASN.1 Sequence.  

Add spec entry to validate that the proto code will handle when .split_messages has been handed a sequence that says its length is larger than the actual data provided.