### PR TITLE
Increment Recog version requirement, bump DAP version to 0.0.12

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'htmlentities'
 gem 'net-dns'
 gem 'bit-struct'
 gem 'geoip-c'
-gem 'recog', '>=2.0'
+gem 'recog', '>=2.0.22'
 
 group :test do
   gem 'rspec', '~> 3.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,14 +21,16 @@ GEM
     gherkin (2.12.2)
       multi_json (~> 1.3)
     htmlentities (4.3.4)
-    mini_portile2 (2.0.0)
+    mini_portile2 (2.1.0)
     multi_json (1.11.2)
     multi_test (0.1.2)
     net-dns (0.8.0)
-    nokogiri (1.6.7.1)
-      mini_portile2 (~> 2.0.0.rc2)
+    nokogiri (1.6.8)
+      mini_portile2 (~> 2.1.0)
+      pkg-config (~> 1.1.7)
     oj (2.14.2)
-    recog (2.0.17)
+    pkg-config (1.1.7)
+    recog (2.0.22)
       nokogiri
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
@@ -54,8 +56,8 @@ DEPENDENCIES
   htmlentities
   net-dns
   oj
-  recog (>= 2.0)
+  recog (>= 2.0.22)
   rspec (~> 3.1.0)
 
 BUNDLED WITH
-   1.10.6
+   1.12.5

--- a/lib/dap/version.rb
+++ b/lib/dap/version.rb
@@ -1,3 +1,3 @@
 module Dap
-  VERSION = "0.0.11"
+  VERSION = "0.0.12"
 end


### PR DESCRIPTION
Require Recog 2.0.22 or higher
Bump DAP to 0.0.12