### PR TITLE
Fail when rename is used without a value to rename to

### DIFF
--- a/lib/dap/filter/simple.rb
+++ b/lib/dap/filter/simple.rb
@@ -7,6 +7,15 @@ module Filter
 
 class FilterRename
   include Base
+
+  def initialize(args)
+    super
+    missing_rename = self.opts.select { |k, v| v.nil? }.keys
+    unless missing_rename.empty?
+      fail "Missing new name for renames of #{missing_rename.join(',')}"
+    end
+  end
+
   def process(doc)
     self.opts.each_pair do |k,v|
       if doc.has_key?(k)


### PR DESCRIPTION
A subtle bug I've encountered a few times:

```
$  echo foo,bar,baf | ./bin/dap csv + rename 1 + json
{"2":"bar","3":"baf","^#1":[null,"foo"]}
$  echo foo,bar,baf | ./bin/dap csv + rename 1 + csv header=t fields=1,2,3
1,2,3
"",bar,baf
```

In both cases, I forgot to include the value to rename the `1` field to, resulting in corruption of that field and potentially tricky data after that.  This change simply detects when `rename` is used incorrectly and fails like other filters/etc do.


```
$  echo foo,bar,baf | ./bin/dap csv + rename 1 + csv
/Users/jhart/rapid7/dap/lib/dap/filter/simple.rb:15:in `initialize': Missing new name for renames of 1 (RuntimeError)
	from /Users/jhart/rapid7/dap/lib/dap.rb:31:in `new'
	from /Users/jhart/rapid7/dap/lib/dap.rb:31:in `create_filter'
	from ./bin/dap:107:in `block in <main>'
	from ./bin/dap:106:in `each'
	from ./bin/dap:106:in `<main>'
```