### PR TITLE
Add reverse transform to dap

### DIFF
--- a/lib/dap/filter/simple.rb
+++ b/lib/dap/filter/simple.rb
@@ -154,6 +154,8 @@ class FilterTransform
     self.opts.each_pair do |k,v|
       if doc.has_key?(k)
         case v
+        when 'reverse'
+          doc[k] = doc[k].to_s.reverse
         when 'downcase'
           doc[k] = doc[k].to_s.downcase
         when 'upcase'

--- a/lib/dap/version.rb
+++ b/lib/dap/version.rb
@@ -1,3 +1,3 @@
 module Dap
-  VERSION = "0.0.16"
+  VERSION = "0.0.17"
 end

--- a/spec/dap/filter/simple_filter_spec.rb
+++ b/spec/dap/filter/simple_filter_spec.rb
@@ -18,3 +18,17 @@ describe Dap::Filter::FilterFlatten do
     end
   end
 end
+
+describe Dap::Filter::FilterTransform do
+  describe '.process' do
+
+    let(:filter) { described_class.new(['foo=reverse']) }
+
+    context 'ASCII' do
+      let(:process) { filter.process({'foo' => 'abc123'}) }
+      it 'is reversed' do
+        expect(process).to eq(['foo' => '321cba'])
+      end
+    end
+  end
+end

--- a/spec/dap/filter/simple_filter_spec.rb
+++ b/spec/dap/filter/simple_filter_spec.rb
@@ -30,5 +30,12 @@ describe Dap::Filter::FilterTransform do
         expect(process).to eq(['foo' => '321cba'])
       end
     end
+
+    context 'UTF-8' do
+      let(:process) { filter.process({'foo' => '☹☠'}) }
+      it 'is reversed' do
+        expect(process).to eq(['foo' => '☠☹'])
+      end
+    end
   end
 end


### PR DESCRIPTION
I found this useful/necessary as part of some work on [Sonar's](https://sonar.labs.rapid7.com) [FDNS](https://scans.io/study/sonar.fdns_v2) study.  It may be useful elsewhere too so I decided to add it to `dap`:

```
echo '{"foo": "abc123", "bar": "abc123" }' | dap json + transform foo=reverse + json | jq
{
  "foo": "321cba",
  "bar": "abc123"
}
```