### PR TITLE
Update dap to handle HTML attributes with varying case

### DIFF
--- a/lib/dap/filter/http.rb
+++ b/lib/dap/filter/http.rb
@@ -28,7 +28,6 @@ module HTMLGhetto
 
       # Skip non-alpha elements
       next unless name =~ /^[a-zA-Z]/
-      name = name.downcase
 
       # Convert newlines to spaces & strip trailing />
       astr = astr.gsub(/\n/, ' ').sub(/\/$/, '')

--- a/lib/dap/filter/http.rb
+++ b/lib/dap/filter/http.rb
@@ -28,6 +28,7 @@ module HTMLGhetto
 
       # Skip non-alpha elements
       next unless name =~ /^[a-zA-Z]/
+      name = name.downcase
 
       # Convert newlines to spaces & strip trailing />
       astr = astr.gsub(/\n/, ' ').sub(/\/$/, '')
@@ -38,7 +39,7 @@ module HTMLGhetto
        Shellwords.shellwords(astr).each do |attr_str|
           aname, avalue = attr_str.split('=', 2).map{|x| x.to_s.strip }
           avalue = avalue.to_s.gsub(/^\"|"$/, '')
-          o[aname] = @coder.decode(avalue)
+          o[aname.downcase] = @coder.decode(avalue)
         end
       rescue ::Interrupt
         raise $!
@@ -47,7 +48,7 @@ module HTMLGhetto
         astr.to_s.split(/\s+/).each do |attr_str|
           aname, avalue = attr_str.split('=', 2).map{|x| x.to_s.strip }
           avalue = avalue.to_s.gsub(/^\"|"$/, '')
-          o[aname] = @coder.decode(avalue)
+          o[aname.downcase] = @coder.decode(avalue)
         end
       end
       res << o

--- a/spec/dap/filter/http_filter_spec.rb
+++ b/spec/dap/filter/http_filter_spec.rb
@@ -51,3 +51,31 @@ describe Dap::Filter::FilterDecodeHTTPReply do
 
   end
 end
+
+describe Dap::Filter::FilterHTMLLinks do
+  describe '.process' do
+
+    let(:filter) { described_class.new(['data']) }
+
+    context 'lowercase' do
+      let(:processed) { filter.process({'data' => '<a href="a"/><a href="b"/>'}) }
+      it 'extracted the correct links' do
+        expect(processed.map { |p| p['link'] }).to eq(%w(a b))
+      end
+    end
+
+    context 'uppercase' do
+      let(:processed) { filter.process({'data' => '<A HREF="a"/><A HREF="b"/>'}) }
+      it 'extracted the correct links' do
+        expect(processed.map { |p| p['link'] }).to eq(%w(a b))
+      end
+    end
+
+    context 'scattercase' do
+      let(:processed) { filter.process({'data' => '<A HrEf="a"/><A HrEf="b"/>'}) }
+      it 'extracted the correct links' do
+        expect(processed.map { |p| p['link'] }).to eq(%w(a b))
+      end
+    end
+  end
+end


### PR DESCRIPTION
This works (no uppercase)

```
$  echo "<html><body><a href='http://fo.bar/baf'/></body></html>" | dap csv +  rename 1=data  + html_links data + json              
{"data":"<html><body><a href='http://fo.bar/baf'/></body></html>","link":"http://fo.bar/baf","element":"a"}
```

This does not (uppercase attributes):

```
echo "<html><body><a HREF='http://fo.bar/baf'/></body></html>" | dap csv +  rename 1=data  + html_links data + json
```

This impacts all of the HTML related filters in `dap`.