### PR TITLE
Add new filter to stack/nest 'flattened' data structures (with periods)

### DIFF
--- a/lib/dap/filter/simple.rb
+++ b/lib/dap/filter/simple.rb
@@ -202,10 +202,11 @@ class FilterStack
   def process(doc)
     new_doc = doc.clone
     self.opts.each_pair do |k,|
+      k_re = /^#{k}\.(?<sub_key>.+)$/
       doc.each do |fk,fv|
-        if /\.(?<sub_key>.+)$/ =~ fk
+        if md = k_re.match(fk)
           new_doc[k] ||= {}
-          new_doc[k][sub_key] = fv
+          new_doc[k][md[:sub_key]] = fv
         end
       end
     end

--- a/lib/dap/filter/simple.rb
+++ b/lib/dap/filter/simple.rb
@@ -197,6 +197,22 @@ class FilterFlatten
   end
 end
 
+class FilterStack
+  include Base
+  def process(doc)
+    new_doc = doc.clone
+    self.opts.each_pair do |k,|
+      doc.each do |fk,fv|
+        if /\.(?<sub_key>.+)$/ =~ fk
+          new_doc[k] ||= {}
+          new_doc[k][sub_key] = fv
+        end
+      end
+    end
+   [ new_doc ]
+  end
+end
+
 class FilterTruncate
   include Base
   def process(doc)

--- a/lib/dap/filter/simple.rb
+++ b/lib/dap/filter/simple.rb
@@ -197,7 +197,7 @@ class FilterFlatten
   end
 end
 
-class FilterStack
+class FilterExpand
   include Base
   def process(doc)
     new_doc = doc.clone

--- a/spec/dap/filter/simple_filter_spec.rb
+++ b/spec/dap/filter/simple_filter_spec.rb
@@ -31,6 +31,13 @@ describe Dap::Filter::FilterStack do
       end
     end
 
+    context 'ignore all but specified  unnested json' do
+      let(:process) { filter.process({"foo.bar" => "baz", "baf.blah" => "baz" }) }
+      it 'has new stacked keys' do
+        expect(process).to eq([{"foo" => {"bar" => "baz"}, "foo.bar" => "baz", "baf.blah" => "baz"}])
+      end
+    end
+
     context 'ignore nested json' do
       let(:process) { filter.process({"foo" => "bar"}) }
       it 'is the same as the original document' do

--- a/spec/dap/filter/simple_filter_spec.rb
+++ b/spec/dap/filter/simple_filter_spec.rb
@@ -19,6 +19,27 @@ describe Dap::Filter::FilterFlatten do
   end
 end
 
+describe Dap::Filter::FilterStack do
+  describe '.process' do
+
+    let(:filter) { described_class.new(["foo"]) }
+
+    context 'stack unnested json' do
+      let(:process) { filter.process({"foo.bar" => "baz"}) }
+      it 'has new stacked keys' do
+        expect(process).to eq([{"foo" => {"bar" => "baz"}, "foo.bar" => "baz"}])
+      end
+    end
+
+    context 'ignore nested json' do
+      let(:process) { filter.process({"foo" => "bar"}) }
+      it 'is the same as the original document' do
+        expect(process).to eq([{"foo" => "bar"}])
+      end
+    end
+  end
+end
+
 describe Dap::Filter::FilterTransform do
   describe '.process' do
 

--- a/spec/dap/filter/simple_filter_spec.rb
+++ b/spec/dap/filter/simple_filter_spec.rb
@@ -19,21 +19,21 @@ describe Dap::Filter::FilterFlatten do
   end
 end
 
-describe Dap::Filter::FilterStack do
+describe Dap::Filter::FilterExpand do
   describe '.process' do
 
     let(:filter) { described_class.new(["foo"]) }
 
-    context 'stack unnested json' do
+    context 'expand unnested json' do
       let(:process) { filter.process({"foo.bar" => "baz"}) }
-      it 'has new stacked keys' do
+      it 'has new expanded keys' do
         expect(process).to eq([{"foo" => {"bar" => "baz"}, "foo.bar" => "baz"}])
       end
     end
 
     context 'ignore all but specified  unnested json' do
       let(:process) { filter.process({"foo.bar" => "baz", "baf.blah" => "baz" }) }
-      it 'has new stacked keys' do
+      it 'has new expanded keys' do
         expect(process).to eq([{"foo" => {"bar" => "baz"}, "foo.bar" => "baz", "baf.blah" => "baz"}])
       end
     end


### PR DESCRIPTION
This is meant to be the reverse of the `flatten` filter, taking data like:

```
{
  "foo.bar": "baf"
}
```

And turning it into:

```
{
  "foo": {
    "bar": "baf"
  }
}
```

Neither `flatten` or `expand` support flattening or expanding beyond the first level, so beware.  

Example usage:

```
$  echo '{"foo.bar": "baf" }' | ./bin/dap json + expand foo + json | jq                 
{
  "foo.bar": "baf",
  "foo": {
    "bar": "baf"
  }
}
$  echo '{"foo.bar": "baf" }' | ./bin/dap json + expand foo + remove foo.bar + json | jq
{
  "foo": {
    "bar": "baf"
  }
}
```