### PR TITLE
Add copy filter for copying fields

### DIFF
--- a/lib/dap/filter/simple.rb
+++ b/lib/dap/filter/simple.rb
@@ -5,6 +5,19 @@ require 'digest/sha2'
 module Dap
 module Filter
 
+class FilterCopy
+  include Base
+
+  def process(doc)
+    self.opts.each_pair do |k,v|
+      if doc.has_key?(k)
+        doc[v] = doc[k]
+      end
+    end
+   [ doc ]
+  end
+end
+
 class FilterRename
   include Base
 

--- a/spec/dap/filter/simple_filter_spec.rb
+++ b/spec/dap/filter/simple_filter_spec.rb
@@ -1,3 +1,17 @@
+describe Dap::Filter::FilterCopy do
+  describe '.process' do
+
+    let(:filter) { described_class.new(["foo=bar"]) }
+
+    context 'copy one json field to another' do
+      let(:process) { filter.process({"foo" => "bar"}) }
+      it 'copies and leaves the original field' do
+        expect(process).to eq([{"foo" => "bar", "bar" => "bar"}])
+      end
+    end
+  end
+end
+
 describe Dap::Filter::FilterFlatten do
   describe '.process' do
 


### PR DESCRIPTION
```
$  echo '{"foo": "bar"}' | ./bin/dap json + copy foo=bar + json                                                              
{"foo":"bar","bar":"bar"}
```