### PR TITLE
Add match_remove filter, used for removing keys by regex

### DIFF
--- a/lib/dap/filter/simple.rb
+++ b/lib/dap/filter/simple.rb
@@ -26,6 +26,19 @@ class FilterRename
    [ doc ]
   end
 end
+class FilterMatchRemove
+  include Base
+  def process(doc)
+    self.opts.each_pair do |re,_|
+      doc.each_key do |k|
+        if k.match(re)
+          doc.delete(k)
+        end
+      end
+    end
+   [ doc ]
+  end
+end
 
 class FilterRemove
   include Base

--- a/spec/dap/filter/simple_filter_spec.rb
+++ b/spec/dap/filter/simple_filter_spec.rb
@@ -47,6 +47,20 @@ describe Dap::Filter::FilterExpand do
   end
 end
 
+describe Dap::Filter::FilterMatchRemove do
+  describe '.process' do
+
+    let(:filter) { described_class.new(["foo."]) }
+
+    context 'with similar keys' do
+      let(:process) { filter.process({"foo" => "bar", "foo.blah" => "blah", "foo.bar" => "baz"}) }
+      it 'removes the expected keys' do
+        expect(process).to eq([{"foo" => "bar"}])
+      end
+    end
+  end
+end
+
 describe Dap::Filter::FilterTransform do
   describe '.process' do
 


### PR DESCRIPTION
```
echo '{"foo": "bar", "foo.blah": "blah" }' | ./bin/dap json + match_remove foo.  + json
{"foo":"bar"}

```