### PR TITLE
Update dap to support proper collection/storage of HTTP headers

### DIFF
--- a/lib/dap/filter/http.rb
+++ b/lib/dap/filter/http.rb
@@ -203,8 +203,6 @@ class FilterDecodeHTTPReply
     # Some buggy systems exclude the header entirely
     body ||= head
 
-    File.open("/tmp/foo", 'w') { |file| file.write(save) }
-
     content_encoding = save["http_raw_headers"]["content-encoding"]
 
     if content_encoding && content_encoding.include?("gzip")

--- a/lib/dap/filter/http.rb
+++ b/lib/dap/filter/http.rb
@@ -175,11 +175,11 @@ class FilterDecodeHTTPReply
 
           when 'date'
             d = DateTime.parse(header_value) rescue nil
-            save["http_date"] = d.to_time.strftime("%Y%m%dT%H:%M:%S") if d
+            save["http_date"] = d.to_time.utc.strftime("%Y%m%dT%H:%M:%S%z") if d
 
           when 'last-modified'
             d = DateTime.parse(header_value) rescue nil
-            save["http_modified"] = d.to_time.strftime("%Y%m%dT%H:%M:%S") if d
+            save["http_modified"] = d.to_time.utc.strftime("%Y%m%dT%H:%M:%S%z") if d
 
           when 'location'
             save["http_location"] = header_value

--- a/lib/dap/version.rb
+++ b/lib/dap/version.rb
@@ -1,3 +1,3 @@
 module Dap
-  VERSION = "0.0.20"
+  VERSION = "0.1.0"
 end

--- a/spec/dap/filter/http_filter_spec.rb
+++ b/spec/dap/filter/http_filter_spec.rb
@@ -14,7 +14,7 @@ describe Dap::Filter::FilterDecodeHTTPReply do
     end
 
     context 'decoding uncompressed response' do
-      let(:decode) { filter.decode("HTTP/1.0 200 OK\r\nHeader1: value1\r\n\r\nstuff") }
+      let(:decode) { filter.decode("HTTP/1.0 200 OK\r\nHeader1: value1\r\nHow(}does<htTp=work?:itdoesn't\r\nHeader2: value2\r\nHEADER2: VALUE2\r\n\r\nstuff") }
 
       it 'correctly sets status code' do
         expect(decode['http_code']).to eq(200)
@@ -28,8 +28,8 @@ describe Dap::Filter::FilterDecodeHTTPReply do
         expect(decode['http_body']).to eq('stuff')
       end
 
-      it 'correct extracts header(s)' do
-        expect(decode['http_raw_headers']).to eq({'header1' => 'value1'})
+      it 'correctly extracts http_raw_headers' do
+        expect(decode['http_raw_headers']).to eq({'header1' => ['value1'], 'header2' => ['value2', 'VALUE2']})
       end
     end
 

--- a/spec/dap/filter/http_filter_spec.rb
+++ b/spec/dap/filter/http_filter_spec.rb
@@ -35,12 +35,12 @@ describe Dap::Filter::FilterDecodeHTTPReply do
 
       it 'extracts Date http header' do
         expect(decode_date['http_raw_headers']['date']).to eq(["Fri, 24 Mar 2017 15:34:04 GMT"])
-	expect(decode_date['http_date']).to eq("20170324T08:34:04")
+	expect(decode_date['http_date']).to eq("20170324T15:34:04+0000")
       end
 
       it 'extracts Last-Modified http header' do
         expect(decode_date['http_raw_headers']['last-modified']).to eq(["Fri, 24 Mar 2013 15:34:04 GMT"])
-	expect(decode_date['http_modified']).to eq("20130324T08:34:04")
+	expect(decode_date['http_modified']).to eq("20130324T15:34:04+0000")
       end
     end
 


### PR DESCRIPTION
In particular, addressing:

  * Duplicate header values (values now stored as a list for the case-insensitive header name)
  * Storage of valid/invalid headers.  Previously, `dap` assumed that header names were A-Z, 0-9 and underscore only, which is close in most cases but incorrect according to various RFCs and various edge cases.

Note that this changes the format of the `raw_http_headers` field for HTTP, and as such we've bumped the minor version.