### PR TITLE
Filter: rename_subkey_match

### DIFF
--- a/lib/dap/filter/simple.rb
+++ b/lib/dap/filter/simple.rb
@@ -58,8 +58,8 @@ class FilterRenameSubkeyMatch
     field, original, updated = self.opts
     return [ doc ] unless doc[field].is_a?(::Hash)
     doc[field].each_key do |k|
-        new_k = k.gsub(original, updated)
-        temp_field[new_k] = doc[field][k]
+      new_k = k.gsub(original, updated)
+      temp_field[new_k] = doc[field][k]
     end
     doc[field] = temp_field
     [ doc ]

--- a/lib/dap/filter/simple.rb
+++ b/lib/dap/filter/simple.rb
@@ -39,6 +39,33 @@ class FilterRename
    [ doc ]
   end
 end
+
+# Example below replaces periods with underscores in the names of all keys
+# one level below 'my_key'
+# rename_subkey_match my_key '.' '_'
+class FilterRenameSubkeyMatch
+  attr_accessor :name, :opts
+
+  def initialize(args)
+    self.name = Dap::Factory.name_from_class(self.class)
+    self.opts = {}
+    fail "Expected 3 arguments to '#{self.name}' but got #{args.size}" unless args.size == 3
+    self.opts = args
+  end
+
+  def process(doc)
+    temp_field = {}
+    field, original, updated = self.opts
+    return [ doc ] unless doc[field].is_a?(::Hash)
+    doc[field].each_key do |k|
+        new_k = k.gsub(original, updated)
+        temp_field[new_k] = doc[field][k]
+    end
+    doc[field] = temp_field
+    [ doc ]
+  end
+end
+
 class FilterMatchRemove
   include Base
   def process(doc)

--- a/spec/dap/filter/simple_filter_spec.rb
+++ b/spec/dap/filter/simple_filter_spec.rb
@@ -45,7 +45,7 @@ describe Dap::Filter::FilterExpand do
       end
     end
 
-    context 'ignore all but specified  unnested json' do
+    context 'ignore all but specified unnested json' do
       let(:process) { filter.process({"foo.bar" => "baz", "baf.blah" => "baz" }) }
       it 'has new expanded keys' do
         expect(process).to eq([{"foo" => {"bar" => "baz"}, "foo.bar" => "baz", "baf.blah" => "baz"}])
@@ -56,6 +56,27 @@ describe Dap::Filter::FilterExpand do
       let(:process) { filter.process({"foo" => "bar"}) }
       it 'is the same as the original document' do
         expect(process).to eq([{"foo" => "bar"}])
+      end
+    end
+  end
+end
+
+describe Dap::Filter::FilterRenameSubkeyMatch do
+  describe '.process' do
+
+    let(:filter) { described_class.new(['foo', '.', '_']) }
+
+    context 'with subkeys' do
+      let(:process) { filter.process({"foo" => {"bar.one" => "baz", "bar.two" => "baz"}, "foo.bar" => "baz", "bar" => {"bar.one" => "baz", "bar.two" => "baz"}}) }
+      it 'renames keys as expected' do
+        expect(process).to eq([{"foo" => {"bar_one" => "baz", "bar_two" => "baz"}, "foo.bar" => "baz", "bar" => {"bar.one" => "baz", "bar.two" => "baz"}}])
+      end
+    end
+
+    context 'without subkeys' do
+      let(:process) { filter.process({"foo" => "bar", "foo.blah" => "blah", "foo.bar" => "baz"}) }
+      it 'produces unchanged output without errors' do
+        expect(process).to eq([{"foo" => "bar", "foo.blah" => "blah", "foo.bar" => "baz"}])
       end
     end
   end


### PR DESCRIPTION
Add a filter that will perform a global replace of one string for another string in **names** of all the keys **one level below** the specified subkey.  The immediate use for this is to remove periods from the names of keys in order to make them easier to process with certain systems.

#### Syntax
```
rename_subkey_match <key> <original_string> <replacement_string>
```

#### Example
The following replaces the periods in the names of the keys under the `foo` key with underscores:

##### Before
```
{
  "foo": {
    "bar.one": "baz",
    "bar.two": "baz"
  }
}
```

##### After
```
echo '{"foo": {"bar.one": "baz", "bar.two":"baz"}}' | bin/dap json + rename_subkey_match foo . _ + json | jq

{
  "foo": {
    "bar_one": "baz",
    "bar_two": "baz"
  }
}
```

#### More complex example

```

{
  "foo": {
    "gizmo.bar.one": "baz",
    "gizmo.bar.two": "baz"
  }
}

echo '{"foo": {"gizmo.bar.one": "baz", "gizmo.bar.two":"baz"}}' | bin/dap json + rename_subkey_match foo 'gizmo.' 'doodad_' + json | jq

{
  "foo": {
    "doodad_bar.one": "baz",
    "doodad_bar.two": "baz"
  }
}

```