### PR TITLE
Support parsing of HTTP responses without HTTP reason phrase

### DIFF
--- a/lib/dap/filter/http.rb
+++ b/lib/dap/filter/http.rb
@@ -139,10 +139,10 @@ class FilterDecodeHTTPReply
     lines = data.split(/\r?\n/)
     resp  = lines.shift
     save  = {}
-    return save if resp !~ /^HTTP\/\d+\.\d+\s+(\d+)\s+(.*)/
+    return save if resp !~ /^HTTP\/\d+\.\d+\s+(\d+)(?:\s+(.*))?/
 
     save["http_code"] = $1.to_i
-    save["http_message"] = $2.strip
+    save["http_message"] = ($2 ? $2.strip : '')
     save["http_raw_headers"] = {}
 
     clen = nil

--- a/spec/dap/filter/http_filter_spec.rb
+++ b/spec/dap/filter/http_filter_spec.rb
@@ -72,6 +72,14 @@ describe Dap::Filter::FilterDecodeHTTPReply do
       end
     end
 
+    context 'decoding responses that are missing the "reason phrase", an RFC anomaly' do
+      let(:decode) { filter.decode("HTTP/1.1 301\r\nDate: Tue, 28 Mar 2017 20:46:52 GMT\r\nContent-Type: text/html\r\nContent-Length: 177\r\nConnection: close\r\nLocation: http://www.example.com/\r\n\r\nstuff") }
+
+      it 'decodes anyway' do
+        expect(decode['http_body']).to eq('stuff')
+      end
+    end
+
   end
 end
 


### PR DESCRIPTION
According to various interpretations of RFC2616, the "reason phrase" is optional in HTTP responses.  So `"HTTP/1.0 200 OK"` is just as valid as `"HTTP/1.0 200"`.  Weird but valid.  This updates `dap` to parse responses like this.