### PR TITLE
Add match_select for selecting keys based on regular expressions

### DIFF
--- a/lib/dap/filter/simple.rb
+++ b/lib/dap/filter/simple.rb
@@ -91,6 +91,21 @@ class FilterRemove
   end
 end
 
+class FilterMatchSelect
+  include Base
+  def process(doc)
+    ndoc = {}
+    self.opts.each_pair do |re,|
+      doc.each_key do |k|
+        if k.match(re)
+          ndoc[k] = doc[k]
+        end
+      end
+    end
+   (ndoc.keys.length == 0) ? [] : [ ndoc ]
+  end
+end
+
 class FilterSelect
   include Base
   def process(doc)

--- a/spec/dap/filter/simple_filter_spec.rb
+++ b/spec/dap/filter/simple_filter_spec.rb
@@ -96,6 +96,34 @@ describe Dap::Filter::FilterMatchRemove do
   end
 end
 
+describe Dap::Filter::FilterMatchSelect do
+  describe '.process' do
+
+    let(:filter) { described_class.new(["foo."]) }
+
+    context 'with similar keys' do
+      let(:process) { filter.process({"foo" => "bar", "foo.blah" => "blah", "foo.bar" => "baz"}) }
+      it 'selects the expected keys' do
+        expect(process).to eq([{"foo.blah" => "blah", "foo.bar" => "baz"}])
+      end
+    end
+  end
+end
+
+describe Dap::Filter::FilterSelect do
+  describe '.process' do
+
+    let(:filter) { described_class.new(["foo"]) }
+
+    context 'with similar keys' do
+      let(:process) { filter.process({"foo" => "bar", "foobar" => "blah"}) }
+      it 'selects the expected keys' do
+        expect(process).to eq([{"foo" => "bar"}])
+      end
+    end
+  end
+end
+
 describe Dap::Filter::FilterTransform do
   describe '.process' do
 


### PR DESCRIPTION
For when just `select` isn't good enough.

```
$  echo '{"bar.one": "baz", "bar.two":"baz"}' | bin/dap json + match_select '^bar' + json                                                                   
{"bar.one":"baz","bar.two":"baz"}
$  echo '{"bar.one": "baz", "bar.two":"baz"}' | bin/dap json + match_select '^bar.t' + json
{"bar.two":"baz"}
```