### PR TITLE
Update dap's http filter to decode chunked responses

### DIFF
--- a/lib/dap/filter/http.rb
+++ b/lib/dap/filter/http.rb
@@ -175,6 +175,7 @@ class FilterDecodeHTTPReply
         end
       end
 
+      # chunked-encoding allows headers to occur after the chunks, so parse those
       if offset < raw_body.size
         save.merge!(parse_headers(raw_body.slice(offset, raw_body.size).split(/\r?\n/)))
       end

--- a/spec/dap/filter/http_filter_spec.rb
+++ b/spec/dap/filter/http_filter_spec.rb
@@ -72,6 +72,15 @@ describe Dap::Filter::FilterDecodeHTTPReply do
       end
     end
 
+    context 'decoding chunked response' do
+      let(:body) { "5\r\nabcde\r\n0F\r\nfghijklmnopqrst\r\n06\r\nuvwxyz\r\n0\r\n" }
+      let(:decode) { filter.decode("HTTP/1.0 200 OK\r\nTransfer-encoding: chunked\r\n\r\n#{body}") }
+
+      it 'correctly dechunks body' do
+        expect(decode['http_body']).to eq(('a'..'z').to_a.join)
+      end
+    end
+
     context 'decoding responses that are missing the "reason phrase", an RFC anomaly' do
       let(:decode) { filter.decode("HTTP/1.1 301\r\nDate: Tue, 28 Mar 2017 20:46:52 GMT\r\nContent-Type: text/html\r\nContent-Length: 177\r\nConnection: close\r\nLocation: http://www.example.com/\r\n\r\nstuff") }
 

--- a/spec/dap/filter/http_filter_spec.rb
+++ b/spec/dap/filter/http_filter_spec.rb
@@ -74,10 +74,14 @@ describe Dap::Filter::FilterDecodeHTTPReply do
 
     context 'decoding chunked response' do
       let(:body) { "5\r\nabcde\r\n0F\r\nfghijklmnopqrst\r\n06\r\nuvwxyz\r\n0\r\n" }
-      let(:decode) { filter.decode("HTTP/1.0 200 OK\r\nTransfer-encoding: chunked\r\n\r\n#{body}") }
+      let(:decode) { filter.decode("HTTP/1.0 200 OK\r\nTransfer-encoding: chunked\r\n\r\n#{body}\r\nSecret: magic\r\n") }
 
       it 'correctly dechunks body' do
         expect(decode['http_body']).to eq(('a'..'z').to_a.join)
+      end
+
+      it 'finds trailing headers' do
+        expect(decode['http_raw_headers']['secret']).to eq(%w(magic))
       end
     end
 


### PR DESCRIPTION
or as well as you can expect for a regex based HTTP client.  

This also works with chunked + gzip responses.  Here is a live example to test with:


```
 curl --Header "Accept-Encoding: gzip" -i --raw https://www.yahoo.com | base64 | dap csv - + rename 1=data  +  transform data=base64decode + decode_http_reply data   + json  | jq -S
```

