### PR TITLE
Handle truncated or invalid chunked responses more cleanly

### DIFF
--- a/lib/dap/filter/http.rb
+++ b/lib/dap/filter/http.rb
@@ -167,7 +167,7 @@ class FilterDecodeHTTPReply
           # advance past this chunk marker and its trailing \r\n
           offset += chunk_size_str.size + 2
           if offset + chunk_size > raw_body.size
-            $stderr.puts "Skipping impossibly large #{chunk_size}-byte ##{chunk_num} chunk"
+            $stderr.puts "Skipping impossibly large #{chunk_size}-byte ##{chunk_num} chunk, at offset #{offset}/#{raw_body.size}"
             break
           end
           # read this chunk, starting from just past the chunk marker and

--- a/lib/dap/filter/http.rb
+++ b/lib/dap/filter/http.rb
@@ -156,6 +156,7 @@ class FilterDecodeHTTPReply
     transfer_encoding = save["http_raw_headers"]["transfer-encoding"]
     if transfer_encoding && transfer_encoding.include?("chunked")
       offset = 0
+      chunk_num = 1
       body = ''
       while (true)
         # read the chunk size from where we currently are.  The chunk size will
@@ -165,11 +166,16 @@ class FilterDecodeHTTPReply
           chunk_size = chunk_size_str.to_i(16)
           # advance past this chunk marker and its trailing \r\n
           offset += chunk_size_str.size + 2
+          if offset + chunk_size > raw_body.size
+            $stderr.puts "Skipping impossibly large #{chunk_size}-byte ##{chunk_num} chunk"
+            break
+          end
           # read this chunk, starting from just past the chunk marker and
           # stopping at the supposed end of the chunk
           body << raw_body.slice(offset, chunk_size)
           # advance the offset to past the end of the chunk and its trailing \r\n
           offset += chunk_size + 2
+          chunk_num += 1
         else
           break
         end
@@ -177,7 +183,16 @@ class FilterDecodeHTTPReply
 
       # chunked-encoding allows headers to occur after the chunks, so parse those
       if offset < raw_body.size
-        save.merge!(parse_headers(raw_body.slice(offset, raw_body.size).split(/\r?\n/)))
+        trailing_headers = parse_headers(raw_body.slice(offset, raw_body.size).split(/\r?\n/))
+        save.merge!(trailing_headers) { |header, old, new|
+          if old.kind_of?(String)
+            [old, new].join(',')
+          elsif old.kind_of?(Hash)
+            old.merge(new) { |nheader, nold, nnew|
+              nold + nnew
+            }
+          end
+        }
       end
     end
 

--- a/spec/dap/filter/http_filter_spec.rb
+++ b/spec/dap/filter/http_filter_spec.rb
@@ -89,6 +89,19 @@ describe Dap::Filter::FilterDecodeHTTPReply do
       end
     end
 
+    context 'decoding bogus chunked responses' do
+      let(:body) { "5\r\nabcde\r\nFF\r\nfghijklmnopqrst\r\n06\r\n" }
+      let(:decode) { filter.decode("HTTP/1.0 200 OK\r\nTransfer-encoding: chunked\r\n\r\n#{body}") }
+
+      it 'reads the partial body' do
+        expect(decode['http_body']).to eq(('a'..'e').to_a.join)
+      end
+
+      it 'finds normal headers' do
+        expect(decode['http_raw_headers']['transfer-encoding']).to eq(%w(chunked))
+      end
+    end
+
     context 'decoding truncated, chunked responses' do
       let(:body) { "5\r\nabcde\r\n0F\r\nfghijklmnopqrst\r\n06\r\n" }
       let(:decode) { filter.decode("HTTP/1.0 200 OK\r\nTransfer-encoding: chunked\r\n\r\n#{body}") }


### PR DESCRIPTION
In cases where an HTTP response is incomplete, or just invalid, trying to read the response chunks will fail if the chunk size is overly large and points beyond the body.