### PR TITLE
Support splitting fields on arbitrary regex boundaries

### DIFF
--- a/lib/dap/filter/simple.rb
+++ b/lib/dap/filter/simple.rb
@@ -369,67 +369,49 @@ class FilterSplitArray
   end
 end
 
-class FilterFieldSplitLine
+class FilterFieldSplit
   include Base
   def process(doc)
     self.opts.each_pair do |k,v|
       if doc.has_key?(k)
-        lcount = 1
-        doc[k].to_s.split(/\n/).each do |line|
-          doc.merge!({ "#{k}.f#{lcount}" => line })
-          lcount += 1
+        count = 1
+        doc[k].to_s.split(Regexp.new(v)).each do |thing|
+          doc.merge!({ "#{k}.f#{count}" => thing })
+          count += 1
         end
       end
     end
    [ doc ]
+  end
+end
+
+class FilterFieldSplitLine
+  def initialize(args)
+    super(args.map { |arg| "#{arg}=\\n" } )
   end
 end
 
 class FilterFieldSplitWord
-  include Base
-  def process(doc)
-    self.opts.each_pair do |k,v|
-      if doc.has_key?(k)
-        wcount = 1
-        doc[k].to_s.split(/\W/).each do |word|
-          doc.merge!({ "#{k}.f#{wcount}" => word })
-          wcount += 1
-        end
-      end
-    end
-   [ doc ]
+  def initialize(args)
+    super(args.map { |arg| "#{arg}=\\W" } )
   end
 end
 
 class FilterFieldSplitTab
-  include Base
-  def process(doc)
-    self.opts.each_pair do |k,v|
-      if doc.has_key?(k)
-        wcount = 1
-        doc[k].to_s.split(/\t/).each do |word|
-          doc.merge!({ "#{k}.f#{wcount}" => word })
-          wcount += 1
-        end
-      end
-    end
-   [ doc ]
+  def initialize(args)
+    super(args.map { |arg| "#{arg}=\\t" } )
   end
 end
 
 class FilterFieldSplitComma
-  include Base
-  def process(doc)
-    self.opts.each_pair do |k,v|
-      if doc.has_key?(k)
-        wcount = 1
-        doc[k].to_s.split(/,/).each do |word|
-          doc.merge!({ "#{k}.f#{wcount}" => word })
-          wcount += 1
-        end
-      end
-    end
-   [ doc ]
+  def initialize(args)
+    super(args.map { |arg| "#{arg}=," } )
+  end
+end
+
+class FilterFieldSplitPeriod < FilterFieldSplit
+  def initialize(args)
+    super(args.map { |arg| "#{arg}=\\." } )
   end
 end
 

--- a/lib/dap/filter/simple.rb
+++ b/lib/dap/filter/simple.rb
@@ -385,25 +385,25 @@ class FilterFieldSplit
   end
 end
 
-class FilterFieldSplitLine
+class FilterFieldSplitLine < FilterFieldSplit
   def initialize(args)
     super(args.map { |arg| "#{arg}=\\n" } )
   end
 end
 
-class FilterFieldSplitWord
+class FilterFieldSplitWord < FilterFieldSplit
   def initialize(args)
     super(args.map { |arg| "#{arg}=\\W" } )
   end
 end
 
-class FilterFieldSplitTab
+class FilterFieldSplitTab < FilterFieldSplit
   def initialize(args)
     super(args.map { |arg| "#{arg}=\\t" } )
   end
 end
 
-class FilterFieldSplitComma
+class FilterFieldSplitComma < FilterFieldSplit
   def initialize(args)
     super(args.map { |arg| "#{arg}=," } )
   end

--- a/spec/dap/filter/simple_filter_spec.rb
+++ b/spec/dap/filter/simple_filter_spec.rb
@@ -144,3 +144,17 @@ describe Dap::Filter::FilterTransform do
     end
   end
 end
+
+describe Dap::Filter::FilterFieldSplit do
+  describe '.process' do
+
+    let(:filter) { described_class.new(["value=\\."]) }
+
+    context 'splitting on regex boundary' do
+      let(:process) { filter.process({"value": "foo.bar.baf"}) }
+      it 'splits correctly' do
+        expect(process).to eq([{"value": "foo.bar.baf", "value.f1": "foo", "value.f2": "bar", "value.f3": "baf"}])
+      end
+    end
+  end
+end

--- a/spec/dap/filter/simple_filter_spec.rb
+++ b/spec/dap/filter/simple_filter_spec.rb
@@ -164,10 +164,24 @@ describe Dap::Filter::FilterFieldSplitPeriod do
 
     let(:filter) { described_class.new(["value"]) }
 
-    context 'splitting on regex boundary' do
+    context 'splitting on period boundary' do
       let(:process) { filter.process({"value" => "foo.bar.baf"}) }
       it 'splits correctly' do
         expect(process).to eq([{"value" => "foo.bar.baf", "value.f1" => "foo", "value.f2" => "bar", "value.f3" => "baf"}])
+      end
+    end
+  end
+end
+
+describe Dap::Filter::FilterFieldSplitLine do
+  describe '.process' do
+
+    let(:filter) { described_class.new(["value"]) }
+
+    context 'splitting on newline boundary' do
+      let(:process) { filter.process({"value" => "foo\nbar\nbaf"}) }
+      it 'splits correctly' do
+        expect(process).to eq([{"value" => "foo\nbar\nbaf", "value.f1" => "foo", "value.f2" => "bar", "value.f3" => "baf"}])
       end
     end
   end

--- a/spec/dap/filter/simple_filter_spec.rb
+++ b/spec/dap/filter/simple_filter_spec.rb
@@ -151,9 +151,23 @@ describe Dap::Filter::FilterFieldSplit do
     let(:filter) { described_class.new(["value=\\."]) }
 
     context 'splitting on regex boundary' do
-      let(:process) { filter.process({"value": "foo.bar.baf"}) }
+      let(:process) { filter.process({"value" => "foo.bar.baf"}) }
       it 'splits correctly' do
-        expect(process).to eq([{"value": "foo.bar.baf", "value.f1": "foo", "value.f2": "bar", "value.f3": "baf"}])
+        expect(process).to eq([{"value" => "foo.bar.baf", "value.f1" => "foo", "value.f2" => "bar", "value.f3" => "baf"}])
+      end
+    end
+  end
+end
+
+describe Dap::Filter::FilterFieldSplitPeriod do
+  describe '.process' do
+
+    let(:filter) { described_class.new(["value"]) }
+
+    context 'splitting on regex boundary' do
+      let(:process) { filter.process({"value" => "foo.bar.baf"}) }
+      it 'splits correctly' do
+        expect(process).to eq([{"value" => "foo.bar.baf", "value.f1" => "foo", "value.f2" => "bar", "value.f3" => "baf"}])
       end
     end
   end


### PR DESCRIPTION
This adds what was requested in #38 by @Manouchehri:

```
$  echo '{"value":"cloud.appspider.rapid7.com"}' | ./bin/dap json + field_split_period value + json | jq
{
  "value": "cloud.appspider.rapid7.com",
  "value.f1": "cloud",
  "value.f2": "appspider",
  "value.f3": "rapid7",
  "value.f4": "com"
}
```

Additionally, I've added support for the larger need here, which is splitting fields on arbitrary regex boundaries:

```
$  echo '{"value":"cloud.appspider.rapid7.com"}' | ./bin/dap json + field_split value=\\\\. + json | jq
{
  "value": "cloud.appspider.rapid7.com",
  "value.f1": "cloud",
  "value.f2": "appspider",
  "value.f3": "rapid7",
  "value.f4": "com"
}
```
