### PR TITLE
Add new int and float transforms

### DIFF
--- a/lib/dap/filter/simple.rb
+++ b/lib/dap/filter/simple.rb
@@ -221,6 +221,15 @@ class FilterTransform
     self.opts.each_pair do |k,v|
       if doc.has_key?(k)
         case v
+        when /^int(?<base>\d+)?$/
+          base = $LAST_MATCH_INFO['base']
+          if base.nil?
+            doc[k] = doc[k].to_s.to_i
+          else
+            doc[k] = doc[k].to_s.to_i(base.to_i)
+          end
+        when 'float'
+          doc[k] = doc[k].to_f
         when 'reverse'
           doc[k] = doc[k].to_s.reverse
         when 'downcase'

--- a/spec/dap/filter/simple_filter_spec.rb
+++ b/spec/dap/filter/simple_filter_spec.rb
@@ -127,19 +127,66 @@ end
 describe Dap::Filter::FilterTransform do
   describe '.process' do
 
-    let(:filter) { described_class.new(['foo=reverse']) }
+    context 'reverse' do
+      let(:filter) { described_class.new(['foo=reverse']) }
 
-    context 'ASCII' do
-      let(:process) { filter.process({'foo' => 'abc123'}) }
-      it 'is reversed' do
-        expect(process).to eq(['foo' => '321cba'])
+      context 'ASCII' do
+        let(:process) { filter.process({'foo' => 'abc123'}) }
+        it 'is reversed' do
+          expect(process).to eq(['foo' => '321cba'])
+        end
+      end
+
+      context 'UTF-8' do
+        let(:process) { filter.process({'foo' => '☹☠'}) }
+        it 'is reversed' do
+          expect(process).to eq(['foo' => '☠☹'])
+        end
       end
     end
 
-    context 'UTF-8' do
-      let(:process) { filter.process({'foo' => '☹☠'}) }
-      it 'is reversed' do
-        expect(process).to eq(['foo' => '☠☹'])
+    context 'int default' do
+      let(:filter) { described_class.new(['val=int']) }
+
+      context 'valid int' do
+        let(:process) { filter.process({'val' => '1'}) }
+        it 'is the correct int' do
+          expect(process).to eq(['val' => 1])
+        end
+      end
+
+      context 'invalid int' do
+        let(:process) { filter.process({'val' => 'cats'}) }
+        it 'is the correct int' do
+          expect(process).to eq(['val' => 0])
+        end
+      end
+    end
+
+    context 'int different base' do
+      let(:filter) { described_class.new(['val=int16']) }
+      let(:process) { filter.process({'val' => 'FF'}) }
+
+      it 'is the correct int' do
+        expect(process).to eq(['val' => 255])
+      end
+    end
+
+    context 'float' do
+      let(:filter) { described_class.new(['val=float']) }
+
+      context 'valid float' do
+        let(:process) { filter.process({'val' => '1.0'}) }
+        it 'is the correct float' do
+          expect(process).to eq(['val' => 1.0])
+        end
+      end
+
+      context 'invalid float' do
+        let(:process) { filter.process({'val' => 'cats.0'}) }
+        it 'is the correct float' do
+          expect(process).to eq(['val' => 0.0])
+        end
       end
     end
   end


### PR DESCRIPTION
Can be used (generally) for converting JSON string values to their respective int and float values.  In anticipation of future needs, I've also added some simple conversion functionality here should any string fields ever represent a number in a different base.


```
# convert string to an int
$  echo '{"val": "1111"}' | ./bin/dap json + transform val=int + json  
{"val":1111}
# convert a string to an int of a different base
$  echo '{"val": "1111"}' | ./bin/dap json + transform val=int16 + json
{"val":4369}
# convert a strign to a float
$  echo '{"val": "1111"}' | ./bin/dap json + transform val=float + json
{"val":1111.0}
```