### PR TITLE
Fail when given an invalid transform

### DIFF
--- a/lib/dap/filter/simple.rb
+++ b/lib/dap/filter/simple.rb
@@ -252,6 +252,8 @@ class FilterTransform
           doc[k] = [ doc[k].to_s ].pack("H*")
         when 'hexencode'
           doc[k] = doc[k].to_s.unpack("H*").first
+        else
+          fail "Invalid transform '#{v}'"
         end
       end
     end

--- a/spec/dap/filter/simple_filter_spec.rb
+++ b/spec/dap/filter/simple_filter_spec.rb
@@ -127,6 +127,13 @@ end
 describe Dap::Filter::FilterTransform do
   describe '.process' do
 
+    context 'invalid transform' do
+      let(:filter) { described_class.new(['foo=blahblah']) }
+      it 'fails' do
+        expect { filter.process({'foo' => 'abc123'}) }.to raise_error(RuntimeError, /Invalid transform/)
+      end
+    end
+
     context 'reverse' do
       let(:filter) { described_class.new(['foo=reverse']) }
 


### PR DESCRIPTION
I've been burned by too many times.  When `transform` is given an invalid transform(ation), it gives no indication that this has happened and allows the pipeline to continue.  I can't think of a scenario where this is advantageous:

```
$  echo lkjadflkajdf | dap csv + transform 1=what + json
{"1":"lkjadflkajdf"}
```

So, this PR changes the functionality of `transform` so that it will throw an error if given an invalid transform:

```
$  echo lkjadflkajdf | ./bin/dap csv + transform 1=what + json
/Users/jhart/rapid7/dap/lib/dap/filter/simple.rb:256:in `block in process': Invalid transform 'what' (RuntimeError)
	from /Users/jhart/rapid7/dap/lib/dap/filter/simple.rb:221:in `each_pair'
	from /Users/jhart/rapid7/dap/lib/dap/filter/simple.rb:221:in `process'
	from ./bin/dap:123:in `block (2 levels) in <main>'
	from ./bin/dap:123:in `collect'
	from ./bin/dap:123:in `block in <main>'
	from ./bin/dap:121:in `each'
	from ./bin/dap:121:in `<main>'
```