### PR TITLE
FilterDecodeDNSVersionReply: Add support for TCP DNS response

### DIFF
--- a/spec/dap/filter/udp_filter_spec.rb
+++ b/spec/dap/filter/udp_filter_spec.rb
@@ -1,0 +1,39 @@
+describe Dap::Filter::FilterDecodeDNSVersionReply do
+  describe '.decode' do
+
+    let(:filter) { described_class.new([]) }
+
+    context 'parsing empty string' do
+      let(:decode) { filter.decode('') }
+      it 'returns an empty hash' do
+        expect(decode).to eq( {} )
+      end
+    end
+
+    base64_string = "AF8074UAAAEAAQABAAAHVkVSU0lPTgRCSU5EAAAQAAPADAAQAAMAAAAAACcmOS44LjJyYzEtUmVkSGF0LTkuOC4yLTAuMzcucmMxLmVsNl83LjXADAACAAMAAAAAAALADA=="
+    test_string = base64_string.to_s.unpack('m*').first
+
+    context 'parsing a partial response' do
+      let(:decode) { filter.decode(test_string[2..10]) }
+      it 'returns an empty hash' do
+        expect(decode).to eq( {} )
+      end
+    end
+
+    context 'parsing TCP DNS response' do
+      let(:decode) { filter.decode(test_string) }
+      it 'returns the correct version' do
+        expect(decode).to eq({ 'dns_version' => '9.8.2rc1-RedHat-9.8.2-0.37.rc1.el6_7.5' })
+      end
+    end
+
+    # strip the first two bytes from the TCP response to mimic a UDP response
+    context 'parsing UDP DNS response' do
+      let(:decode) { filter.decode(test_string[2..-1]) }
+      it 'returns the correct version' do
+        expect(decode).to eq({ 'dns_version' => '9.8.2rc1-RedHat-9.8.2-0.37.rc1.el6_7.5' })
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
The TCP version of the DNS version bind response contains a length value (two bytes) that the UDP version doesn't contain.  The Ruby Net::DNS:Packet lib doesn't have support for this length field. This PR adds support for the TCP version by way of stripping off the first two bytes and attempting to parse again if the first pass fails.

Due the structure of the data and how Net::DNS::Packet parses it invalid data should never be successfully parsed and should always raise an exception.

I've also tried to ensure that the code always returns a hash even on failure.

This PR also adds a couple of tests.

**Sample test**
```
echo AFU074UAAAEAAQABAAAHVkVSU0lPTgRCSU5EAAAQAAPADAAQAAMAAAAAABEQOS4xMC4zLVA0LVVidW50dQd2ZXJzaW9uBGJpbmQAAAIAAwAAAAAAAsA7 | ~/git/dap/bin/dap lines + transform line=base64decode + decode_dns_version_reply line + remove line + lines

9.10.3-P4-Ubuntu
```