### PR TITLE
Add where_regex filter

### DIFF
--- a/lib/dap/filter/simple.rb
+++ b/lib/dap/filter/simple.rb
@@ -159,6 +159,22 @@ class FilterWhere
   end
 end
 
+class FilterWhereRegex
+  attr_accessor :field, :re
+
+
+  def initialize(args)
+    fail "Expected 2 arguments to 'where' but got #{args.size}" unless args.size == 2
+    self.re = Regexp.new(args.last)
+    self.field = args.first
+  end
+
+  def process(doc)
+    return [ doc ] if doc.has_key?(self.field) && doc[self.field] =~ self.re
+    [ ]
+  end
+end
+
 class FilterExclude
   include Base
   def process(doc)

--- a/spec/dap/filter/simple_filter_spec.rb
+++ b/spec/dap/filter/simple_filter_spec.rb
@@ -240,3 +240,45 @@ describe Dap::Filter::FilterFieldSplitLine do
     end
   end
 end
+
+describe Dap::Filter::FilterWhere do
+  describe '.process' do
+
+    let(:filter) { described_class.new(["value", "==", "1"]) }
+
+    context 'matches when it should' do
+      let(:process) { filter.process({"value" => "1"}) }
+      it 'matches' do
+        expect(process).to eq([{"value" => "1"}])
+      end
+    end
+
+    context 'does not match when it should not' do
+      let(:process) { filter.process({"value" => "2"}) }
+      it 'does not match' do
+        expect(process).to eq([])
+      end
+    end
+  end
+end
+
+describe Dap::Filter::FilterWhereRegex do
+  describe '.process' do
+
+    let(:filter) { described_class.new(["value", "^foo-([\d\.]+)$"]) }
+
+    context 'matches when it should' do
+      let(:process) { filter.process({"value" => "foo-1.2.3.4"}) }
+      it 'matches' do
+        expect(process).to eq([{"value" => "foo-1.2.3.4"}])
+      end
+    end
+
+    context 'does not match matches when it should not' do
+      let(:process) { filter.process({"value" => "2"}) }
+      it 'does not match' do
+        expect(process).to eq([])
+      end
+    end
+  end
+end

--- a/spec/dap/filter/simple_filter_spec.rb
+++ b/spec/dap/filter/simple_filter_spec.rb
@@ -265,7 +265,7 @@ end
 describe Dap::Filter::FilterWhereRegex do
   describe '.process' do
 
-    let(:filter) { described_class.new(["value", "^foo-([\d\.]+)$"]) }
+    let(:filter) { described_class.new(["value", "^foo-([\\d\\.]+)$"]) }
 
     context 'matches when it should' do
       let(:process) { filter.process({"value" => "foo-1.2.3.4"}) }


### PR DESCRIPTION
I had written this a while back and ended up not needing it, but figured someone else may find value in it at some point.  This is basically the  more advanced version of the `where` filter so that you can filter out entries by applying regular expressions against their attributes.  The basic usage is:

```
$ echo -en '{"value":"foo-1.2.3"}\n{"value":"blah-adfadf"}' | ./bin/dap 'json + where_regex value ^foo-[\\d\\.]+ + json' 
{"value":"foo-1.2.3"}
```

I've also added rspec coverage for this new feature as well as the existing `where` filter.