### PR TITLE
When tring to re-parse possible DNS responses, handle more exceptions

### DIFF
--- a/lib/dap/filter/udp.rb
+++ b/lib/dap/filter/udp.rb
@@ -48,7 +48,7 @@ class FilterDecodeDNSVersionReply
   def decode(data)
     begin
       r = Net::DNS::Packet.parse(data)
-    rescue
+    rescue ::Exception
       r = nil
     end
 
@@ -58,7 +58,7 @@ class FilterDecodeDNSVersionReply
         # and try again..
         trimmed_data = data[2..-1]
         r = Net::DNS::Packet.parse(trimmed_data)
-      rescue
+      rescue ::Exception
         return {}
       end
     end


### PR DESCRIPTION
As it is, there are use-cases that involve taking blatantly non-DNS data
and parsing it with this code here. When that fails the first time, the
code chops off 2 bytes and tries again.  It is not surprising that this
eventually results in some exceptions due to unidentified parsing bugs
deep in the recursive guts of Net::DNS.

The issue is that not all of these exceptions are caught, so some bad
data may result in exceptions being thrown and in other cases not.  This
handles the `SystemStackError` I encountered several times while
testing and is in-line with how exceptions like this are handled
elsewhere in dap. 

An easy but hacky way to reproduce the issue is just by throwing random data at the DNS decoding process:

```
$  while (true); do                                                                   
  head -c 1000 /dev/urandom | base64 | ./bin/dap lines + rename line=data + transform data=base64decode +  decode_dns_version_reply data + json > /dev/null
done
```

After a short time, I got this exception:

```
/Users/jhart/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/net-dns-0.8.0/lib/net/dns/names.rb:40:in `dn_expand': stack level too deep (SystemStackError)
	from /Users/jhart/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/net-dns-0.8.0/lib/net/dns/names.rb:40:in `dn_expand'
	from /Users/jhart/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/net-dns-0.8.0/lib/net/dns/names.rb:40:in `dn_expand'
	from /Users/jhart/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/net-dns-0.8.0/lib/net/dns/names.rb:40:in `dn_expand'
	from /Users/jhart/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/net-dns-0.8.0/lib/net/dns/names.rb:40:in `dn_expand'
	from /Users/jhart/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/net-dns-0.8.0/lib/net/dns/names.rb:40:in `dn_expand'
	from /Users/jhart/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/net-dns-0.8.0/lib/net/dns/names.rb:40:in `dn_expand'
	from /Users/jhart/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/net-dns-0.8.0/lib/net/dns/names.rb:40:in `dn_expand'
	from /Users/jhart/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/net-dns-0.8.0/lib/net/dns/names.rb:40:in `dn_expand'
	 ... 7273 levels...
	from /Users/jhart/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/dap-0.1.11/bin/dap:121:in `each'
	from /Users/jhart/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/dap-0.1.11/bin/dap:121:in `<top (required)>'
	from /Users/jhart/.rbenv/versions/2.4.1/bin/dap:22:in `load'
```

After this PR I cannot reproduce the exception and the large, real DNS dataset that I originally discovered this with appears to be handled fine after this PR.