### PR TITLE
Add a JSON transform to allow you to interpret (generally) String objects as JSON

### DIFF
--- a/lib/dap/filter/simple.rb
+++ b/lib/dap/filter/simple.rb
@@ -1,6 +1,7 @@
 require 'digest/sha1'
 require 'digest/md5'
 require 'digest/sha2'
+require 'json'
 
 module Dap
 module Filter
@@ -238,6 +239,8 @@ class FilterTransform
           doc[k] = doc[k].to_s.upcase
         when 'ascii'
           doc[k] = doc[k].to_s.gsub(/[\x00-\x1f\x7f-\xff]/n, '')
+        when 'json'
+          doc[k] = JSON.parse(doc[k].to_s)
         when 'utf8encode'
           doc[k] = doc[k].to_s.encode!('UTF-8', invalid: :replace, undef: :replace, replace: '')
         when 'base64decode'

--- a/spec/dap/filter/simple_filter_spec.rb
+++ b/spec/dap/filter/simple_filter_spec.rb
@@ -196,6 +196,23 @@ describe Dap::Filter::FilterTransform do
         end
       end
     end
+
+    context 'json' do
+      let(:filter) { described_class.new(['val=json']) }
+
+      context 'valid json' do
+        let(:process) { filter.process({'val' => '{"nested": "1"}'}) }
+        it 'is the correct JSON' do
+          expect(process).to eq(['val' => { 'nested' => '1' }])
+        end
+      end
+
+      context 'invalid json' do
+        it 'raises on invalid JSON' do
+          expect { filter.process({'val' => '{abc123'}) }.to raise_error(JSON::ParserError)
+        end
+      end
+    end
   end
 end
 


### PR DESCRIPTION
I had a use-case where a JSON structure had field inside of it that was the base64 encoded version of the string representation of more JSON. I wanted to stretch it all out so that it was all JSON so I added a new json transform.

Before:

```
$  echo '{"val": "{\"nested_val\": \"9\"}"}' | ./bin/dap json + transform + select val + json | jq         
{
  "val": "{\"nested_val\": \"9\"}"
}
```

After:

```
$  echo '{"val": "{\"nested_val\": \"9\"}"}' | ./bin/dap json + transform val=json + select val + json | jq 
{
  "val": {
    "nested_val": "9"
  }
}
```

To the best of my knowledge, `JSON.parse` is the safe way to parse JSON from untrusted input.
