### PR TITLE
Only parse WDBRPC replies with valid looking versions.  Fixes #49

### DIFF
--- a/lib/dap/filter/udp.rb
+++ b/lib/dap/filter/udp.rb
@@ -105,6 +105,8 @@ class FilterDecodeWDBRPC_Reply
     return info unless head.to_s.length == 36
     return unless buff.length > 0
     info['agent_ver'] = Dap::Proto::WDBRPC.wdbrpc_decode_str(buff)
+    # if this isn't a recoginized version string, it is likely part of an invalid response and should be skipped
+    return unless info['agent_ver'] =~ /^\d+\.\d+(?:\.\d+)*(?:-alpha)?$/
     info['agent_mtu'] = Dap::Proto::WDBRPC.wdbrpc_decode_int(buff)
     info['agent_mod'] = Dap::Proto::WDBRPC.wdbrpc_decode_int(buff)
     info['rt_type']          = Dap::Proto::WDBRPC.wdbrpc_decode_int(buff)


### PR DESCRIPTION
As described in #49, the WDBRPC parsing code mishandles data that is not obviously WDBRPC data.  In the best case, the resulting data from the decoding is non-sensical.  In the worst case, `dap` will spin indefinitely and likely get killed by OOMkiller or similar.

This PR changes the decoding such that we sanity check the `agent_ver` string obtained from the response, increasing the likelihood that we'll only decode valid responses.

Prior to this PR, in addition to the hang described in #49, there were 31 unique `agent_ver` responses, the vast majority of which are garbage that you'll see when you probe pretty much any port on the public IPv4 Internet -- binary garbage, HTTP responses, etc.    These are all useless and should simply be filtered out.  Now we just get responses that have valid looking versions:

```
$   pigz -dc udp_wdbrpc_17185/2018-05-07-1525669801-udp_wdbrpc_17185_zmap.json.gz  |  ./bin/dap json + rename saddr=ip sport=port + select ip port data + transform data=hexdecode + annotate data=size + decode_wdbrpc_reply data + remove data + select data.agent_ver  + json  |sort | uniq -c | sort -nr
14816 {"data.agent_ver":"2.0"}
 233 {"data.agent_ver":"4.0"}
  77 {"data.agent_ver":"1.0.1"}
   5 {"data.agent_ver":"1.0-alpha"}
```