### PR TITLE
Allow use of newer maxmind geoip dat name

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Using system managed/installed Rubies is possible but fraught with peril.
 DAP depends on [Maxmind's geoip database](http://dev.maxmind.com/geoip/legacy/downloadable/) to be able to append geographic metadata to analyzed datasets.  If you intend on using this capability, run the following as `root`:
 
 ```bash
-sudo mkdir -p /var/lib/geoip && cd /var/lib/geoip && sudo wget http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz && sudo gunzip GeoLiteCity.dat.gz && sudo mv GeoLiteCity.dat geoip.dat && sudo wget http://geolite.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz && sudo gunzip GeoIPASNum.dat.gz
+sudo mkdir -p /var/lib/geoip && cd /var/lib/geoip && sudo wget http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz && sudo gunzip GeoLiteCity.dat.gz && sudo wget http://geolite.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz && sudo gunzip GeoIPASNum.dat.gz
 
 ```
 

--- a/lib/dap/filter/geoip.rb
+++ b/lib/dap/filter/geoip.rb
@@ -8,7 +8,7 @@ module GeoIPLibrary
     File.expand_path( File.join( File.dirname(__FILE__), "..", "..", "..", "data")),
     "/var/lib/geoip"
   ]
-  GEOIP_CITY = %W{ geoip.dat geoip_city.dat GeoCity.dat IP_V4_CITY.dat GeoCityLite.dat }
+  GEOIP_CITY = %W{ geoip.dat geoip_city.dat GeoCity.dat IP_V4_CITY.dat GeoCityLite.dat GeoLiteCity.dat }
   GEOIP_ORGS = %W{ geoip_org.dat IP_V4_ORG.dat }
   GEOIP_ASN = %W{ GeoIPASNum.dat }
 


### PR DESCRIPTION
At least now, according to https://dev.maxmind.com/geoip/legacy/install/city/, there is a slightly different possible name for the Maxmind city geo data.  This PR updates `dap` to allow this and updates the documentation to remove this workaround.