### PR TITLE
Add filters for stripping whitespace

### DIFF
--- a/lib/dap/filter/simple.rb
+++ b/lib/dap/filter/simple.rb
@@ -237,6 +237,12 @@ class FilterTransform
           doc[k] = doc[k].to_s.downcase
         when 'upcase'
           doc[k] = doc[k].to_s.upcase
+        when /^(lstrip|ltrim)$/
+          doc[k] = doc[k].to_s.lstrip
+        when /^(rstrip|rtrim)$/
+          doc[k] = doc[k].to_s.rstrip
+        when /^(strip|trim)$/
+          doc[k] = doc[k].to_s.strip
         when 'ascii'
           doc[k] = doc[k].to_s.gsub(/[\x00-\x1f\x7f-\xff]/n, '')
         when 'json'

--- a/spec/dap/filter/simple_filter_spec.rb
+++ b/spec/dap/filter/simple_filter_spec.rb
@@ -213,6 +213,32 @@ describe Dap::Filter::FilterTransform do
         end
       end
     end
+
+    context 'stripping' do
+      context 'lstrip' do
+        let(:filter) { described_class.new(['foo=lstrip']) }
+        let(:process) { filter.process({'foo' => ' abc123  '}) }
+        it 'lstripped' do
+          expect(process).to eq(['foo' => 'abc123  '])
+        end
+      end
+
+      context 'rstrip' do
+        let(:filter) { described_class.new(['foo=rstrip']) }
+        let(:process) { filter.process({'foo' => ' abc123  '}) }
+        it 'rstripped' do
+          expect(process).to eq(['foo' => ' abc123'])
+        end
+      end
+
+      context 'strip' do
+        let(:filter) { described_class.new(['foo=strip']) }
+        let(:process) { filter.process({'foo' => ' abc123  '}) }
+        it 'stripped' do
+          expect(process).to eq(['foo' => 'abc123'])
+        end
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Adds `lstrip`/`ltrim` to trim leading whitespace, `rstrip`/`rtrim` to trim trailing whitespace, and `strip`/`trim` to do both.

```
$ echo '{"foo": " blah     "}' | ./bin/dap json + transform foo=trim + json
{"foo":"blah"}
```