### PR TITLE
Add match_select_value for selecting key/value pairs by value regex

### DIFF
--- a/lib/dap/filter/simple.rb
+++ b/lib/dap/filter/simple.rb
@@ -107,6 +107,24 @@ class FilterMatchSelect
   end
 end
 
+class FilterMatchSelectKey < FilterMatchSelect
+end
+
+class FilterMatchSelectValue
+  include Base
+  def process(doc)
+    ndoc = {}
+    self.opts.each_pair do |re,|
+      doc.each_key do |k|
+        if doc[k].match(re)
+          ndoc[k] = doc[k]
+        end
+      end
+    end
+   (ndoc.keys.length == 0) ? [] : [ ndoc ]
+  end
+end
+
 class FilterSelect
   include Base
   def process(doc)

--- a/spec/dap/filter/simple_filter_spec.rb
+++ b/spec/dap/filter/simple_filter_spec.rb
@@ -124,6 +124,34 @@ describe Dap::Filter::FilterSelect do
   end
 end
 
+describe Dap::Filter::FilterMatchSelectKey do
+  describe '.process' do
+
+    let(:filter) { described_class.new(["foo."]) }
+
+    context 'with similar keys' do
+      let(:process) { filter.process({"foo" => "bar", "foo.blah" => "blah", "foo.bar" => "baz"}) }
+      it 'selects the expected keys' do
+        expect(process).to eq([{"foo.blah" => "blah", "foo.bar" => "baz"}])
+      end
+    end
+  end
+end
+
+describe Dap::Filter::FilterMatchSelectValue do
+  describe '.process' do
+
+    let(:filter) { described_class.new(["ba"]) }
+
+    context 'with similar keys' do
+      let(:process) { filter.process({"foo" => "bar", "foo.blah" => "blah", "foo.bar" => "baz"}) }
+      it 'selects the expected keys' do
+        expect(process).to eq([{"foo" => "bar", "foo.bar" => "baz"}])
+      end
+    end
+  end
+end
+
 describe Dap::Filter::FilterTransform do
   describe '.process' do
 


### PR DESCRIPTION
`match_select` already exists somewhat ambiguously because it isn't clear that it is selecting attributes based on matching a regex against the key name.  This adds a more obvious name for this filter, `match_select_key`.  While here, I added the complementary `match_select_value` which selects attributes based on applying a regex to their value.

```
$  echo '{"cow": "moo", "cat": "meow"}' | ./bin/dap json + match_select_key ow + json
{"cow":"moo"}
$  echo '{"cow": "moo", "cat": "meow"}' | ./bin/dap json + match_select_value '^me' + json
{"cat":"meow"}
```

I had this sitting uncommitted in my `dap` checkout from a project weeks old that I went a different direction on.  This still seems useful.