### PR TITLE
Add field_replace and field_replace_all

### DIFF
--- a/lib/dap/filter/simple.rb
+++ b/lib/dap/filter/simple.rb
@@ -41,6 +41,41 @@ class FilterRename
   end
 end
 
+class FilterFieldReplace
+  include Base
+  attr_accessor :all
+
+  def initialize(args, all=false)
+    self.all = all
+    super(args)
+    missing_replace = self.opts.select { |k, v| v.nil? }.keys
+    unless missing_replace.empty?
+      fail "Missing search/replace for #{missing_replace.join(',')}"
+    end
+  end
+
+  def process(doc)
+    self.opts.each_pair do |k,v|
+      if doc.has_key?(k)
+        search, replace = v.split('=', 2)
+        search = Regexp.new(search)
+        if self.all
+          doc[k] = doc[k].gsub(search, replace)
+        else
+          doc[k] = doc[k].sub(search, replace)
+        end
+      end
+  end
+   [ doc ]
+  end
+end
+
+class FilterFieldReplaceAll < FilterFieldReplace
+  def initialize(args)
+    super(args, all=true)
+  end
+end
+
 # Example below replaces periods with underscores in the names of all keys
 # one level below 'my_key'
 # rename_subkey_match my_key '.' '_'

--- a/spec/dap/filter/simple_filter_spec.rb
+++ b/spec/dap/filter/simple_filter_spec.rb
@@ -270,16 +270,26 @@ describe Dap::Filter::FilterTransform do
   end
 end
 
-describe Dap::Filter::FilterFieldSplit do
+describe Dap::Filter::FilterFieldReplace do
   describe '.process' do
 
-    let(:filter) { described_class.new(["value=\\."]) }
+    let(:filter) { described_class.new(["value1=foo=bar"]) }
 
-    context 'splitting on regex boundary' do
-      let(:process) { filter.process({"value" => "foo.bar.baf"}) }
-      it 'splits correctly' do
-        expect(process).to eq([{"value" => "foo.bar.baf", "value.f1" => "foo", "value.f2" => "bar", "value.f3" => "baf"}])
-      end
+    let(:process) { filter.process({"value1" => "foo.bar.foo", "value2" => "secret"}) }
+    it 'replaced correctly' do
+      expect(process).to eq([{"value1" => "bar.bar.foo", "value2" => "secret"}])
+    end
+  end
+end
+
+describe Dap::Filter::FilterFieldReplaceAll do
+  describe '.process' do
+
+    let(:filter) { described_class.new(["value1=foo=bar"]) }
+
+    let(:process) { filter.process({"value1" => "foo.bar.foo", "value2" => "secret"}) }
+    it 'replaced correctly' do
+      expect(process).to eq([{"value1" => "bar.bar.bar", "value2" => "secret"}])
     end
   end
 end


### PR DESCRIPTION
These filters take 1 or more arguments, each of which controls theregex/gsub/sub/replace behavior of that field value.

```
$  echo '{"A": "mississippi", "B": "stuff"}' | ./bin/dap json + field_replace A=i=b B=st=fl + json
{"A":"mbssissippi","B":"fluff"}
$  echo '{"A": "mississippi", "B": "stuff"}' | ./bin/dap json + field_replace_all A=i=b B=st=fl + json
{"A":"mbssbssbppb","B":"fluff"}
```