### PR TITLE
Adjust upnp processing 

### DIFF
--- a/lib/dap/filter/udp.rb
+++ b/lib/dap/filter/udp.rb
@@ -83,7 +83,17 @@ class FilterDecodeUPNP_SSDP_Reply
   include BaseDecoder
   def decode(data)
     head = { }
-    data.split(/\n/).each do |line|
+    lines = data.split(/\r?\n/)
+    return if lines.empty?
+    if /^HTTP\/\d+\.\d+\s+(?<http_code>\d+)(?:\s+(?<http_message>.*))?/ =~ lines.first
+      head["upnp_http_code"] = http_code
+      head["upnp_http_message"] = http_message
+    else
+      return
+    end
+
+    lines.shift
+    lines.each do |line|
       k,v = line.strip.split(':', 2)
       next if not k
       head["upnp_#{k.downcase}"] = (v.to_s.strip)


### PR DESCRIPTION
The UPNP response is just basically just HTTP, so I've modified it to only accept valid-seeming UPNP HTTP responses.  I've also had it extract the http_code and http_message similar to how other HTTP decoding is done.  

Old example:


```
$  pigz -dc <some_udp_upnp_1900_from_sonar>  | ./bin/dap  json + select raw_data + rename raw_data=processed_data + transform processed_data=base64decode + decode_upnp_ssdp_reply processed_data  + remove processed_data + expand processed_data + match_remove processed_data. + json | tail -n1 | jq .
{
  "processed_data": {
    "upnp_http/1.1 200 ok": "",
    "upnp_cache-control": "max-age=1800",
    "upnp_ext": "",
    "upnp_location": "http://192.168.0.5:1900/rootDesc.xml",
    "upnp_server": "Ubuntu/7.10 UPnP/1.0 miniupnpd/1.0",
    "upnp_st": "upnp:rootdevice",
    "upnp_usn": "uuid:fc4ec57e-b051-11db-88f8-0060085db3f6::upnp:rootdevice"
  }
}
```

New example:

```
$  pigz -dc <some_udp_upnp_1900_from_sonar>  | ./bin/dap  json + select raw_data + rename raw_data=processed_data + transform processed_data=base64decode + decode_upnp_ssdp_reply processed_data  + remove processed_data + expand processed_data + match_remove processed_data. + json | tail -n1 | jq .
{
  "processed_data": {
    "upnp_http_code": "200",
    "upnp_http_message": "OK",
    "upnp_cache-control": "max-age=1800",
    "upnp_ext": "",
    "upnp_location": "http://192.168.0.5:1900/rootDesc.xml",
    "upnp_server": "Ubuntu/7.10 UPnP/1.0 miniupnpd/1.0",
    "upnp_st": "upnp:rootdevice",
    "upnp_usn": "uuid:fc4ec57e-b051-11db-88f8-0060085db3f6::upnp:rootdevice"
  }
}
```