### PR TITLE
Improve logging for invalid JSON

### DIFF
--- a/lib/dap/input.rb
+++ b/lib/dap/input.rb
@@ -64,8 +64,7 @@ module Input
       begin
         json = Oj.load(line.strip, mode: :strict)
       rescue
-        $stderr.puts "\nRecord is not valid JSON and will be skipped."
-        $stderr.puts line
+        $stderr.puts "Record is not valid JSON and will be skipped: '#{line}'"
         return Error::InvalidFormat
       end
       return Error::Empty unless json


### PR DESCRIPTION
Currently it prints out three lines, a newline, another with the error and third with the line itself.  This collapses the message into one line, making log analysis of `dap` output a bit more sane.