### PR TITLE
Bump ubuntu base and add an entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update
 RUN apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:15.04
+FROM ubuntu:16.04
 
 RUN apt-get update
 RUN apt-get install -y \
@@ -15,11 +15,11 @@ RUN apt-get install -y libxml2-dev zlib1g-dev
 
 RUN gem install bundler
 
-RUN cd /opt && git clone https://github.com/rapid7/dap.git dap && \
-  cd dap && bundle install
-
 RUN apt-get install -y wget && mkdir -p /var/lib/geoip && cd /var/lib/geoip && wget http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz && gunzip GeoLiteCity.dat.gz && mv GeoLiteCity.dat geoip.dat
+
+RUN gem install dap -s https://github.com/rapid7/dap
 
 # Clean up APT when done.
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+ENTRYPOINT ["dap"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:latest
 
 RUN apt-get update
 RUN apt-get install -y \


### PR DESCRIPTION
The dockerfile didn't build due to 404s. Bumping to 18.04LTS as the docker base fixes this. Also, I made the Dockerfile build a "proper" container that installs dap directly from github. Lastly, I added an ENTRYPOINT so running the container immediately runs dap.