### PR TITLE
Improve resiliency of parsing ldap responses

### DIFF
--- a/lib/dap/filter/ldap.rb
+++ b/lib/dap/filter/ldap.rb
@@ -35,6 +35,8 @@ class FilterDecodeLdapSearchResult
     messages.each do |element|
       begin
         elem_decoded = OpenSSL::ASN1.decode(element)
+        parsed_type, parsed_data = Dap::Proto::LDAP.parse_message(elem_decoded)
+        info[parsed_type] = parsed_data if parsed_type && parsed_data
       rescue Exception => e
         err_msg = 'FilterDecodeLdapSearchResult - Unable to decode ASN.1 element'
         $stderr.puts "#{err_msg}: #{e}"
@@ -44,8 +46,6 @@ class FilterDecodeLdapSearchResult
         info['Error'] = { 'errorMessage' => err_msg }
         next
       end
-      parsed_type, parsed_data = Dap::Proto::LDAP.parse_message(elem_decoded)
-      info[parsed_type] = parsed_data if parsed_type && parsed_data
     end
 
     info


### PR DESCRIPTION
As currently written, the `decode_ldap_search_result` filter has exception handling such that if it it encounters trouble with ASN.1 conversion, it'll catch and log the result.  This works, however there are some edge cases that I don't fully understand where the resulting ASN.1 messages fail when handled by the LDAP specific code.  The result is that the entire `dap` pipeline fails, which is suboptimal.

I can't reproduce this locally but pumping random Internet garbage through here seems to cause the problem more of then than not, but pinning down exactly what the data is ... challenging.  

This simply expands the scope of the exception handling safety net to include this occassional failure path.

Example:

```

"/usr/local/rvm/gems/ruby-2.2.2/gems/dap-0.1.21/lib/dap/proto/ldap.rb:236:in parse_message: undefined method tag for 04:String (NoMethodError)"
"from /usr/local/rvm/gems/ruby-2.2.2/gems/dap-0.1.21/lib/dap/filter/ldap.rb:47:in block in decode"
"from /usr/local/rvm/gems/ruby-2.2.2/gems/dap-0.1.21/lib/dap/filter/ldap.rb:35:in each"
"from /usr/local/rvm/gems/ruby-2.2.2/gems/dap-0.1.21/lib/dap/filter/ldap.rb:35:in decode"
"from /usr/local/rvm/gems/ruby-2.2.2/gems/dap-0.1.21/lib/dap/filter/base.rb:27:in block in process"
"from /usr/local/rvm/gems/ruby-2.2.2/gems/dap-0.1.21/lib/dap/filter/base.rb:25:in each_pair"
"from /usr/local/rvm/gems/ruby-2.2.2/gems/dap-0.1.21/lib/dap/filter/base.rb:25:in process"
"from /usr/local/rvm/gems/ruby-2.2.2/gems/dap-0.1.21/bin/dap:123:in block (2 levels) in <top (required)>"
"from /usr/local/rvm/gems/ruby-2.2.2/gems/dap-0.1.21/bin/dap:123:in collect"
"from /usr/local/rvm/gems/ruby-2.2.2/gems/dap-0.1.21/bin/dap:123:in block in <top (required)>"
"from /usr/local/rvm/gems/ruby-2.2.2/gems/dap-0.1.21/bin/dap:121:in each"
"from /usr/local/rvm/gems/ruby-2.2.2/gems/dap-0.1.21/bin/dap:121:in <top (required)>"
"from /usr/local/rvm/gems/ruby-2.2.2/bin/dap:23:in load"
"from /usr/local/rvm/gems/ruby-2.2.2/bin/dap:23:in <main>"
"from /usr/local/rvm/gems/ruby-2.2.2/bin/ruby_executable_hooks:15:in eval"
"from /usr/local/rvm/gems/ruby-2.2.2/bin/ruby_executable_hooks:15:in <main>"
"FilterDecodeLdapSearchResult - Unable to decode ASN.1 element: header too long"
"/usr/local/rvm/gems/ruby-2.2.2/gems/dap-0.1.21/lib/dap/filter/ldap.rb:37:in decode"
"/usr/local/rvm/gems/ruby-2.2.2/gems/dap-0.1.21/lib/dap/filter/ldap.rb:37:in block in decode"
"/usr/local/rvm/gems/ruby-2.2.2/gems/dap-0.1.21/lib/dap/filter/ldap.rb:35:in each"
"/usr/local/rvm/gems/ruby-2.2.2/gems/dap-0.1.21/lib/dap/filter/ldap.rb:35:in decode"
"/usr/local/rvm/gems/ruby-2.2.2/gems/dap-0.1.21/lib/dap/filter/base.rb:27:in block in process"
"/usr/local/rvm/gems/ruby-2.2.2/gems/dap-0.1.21/lib/dap/filter/base.rb:25:in each_pair"
"/usr/local/rvm/gems/ruby-2.2.2/gems/dap-0.1.21/lib/dap/filter/base.rb:25:in process"
"/usr/local/rvm/gems/ruby-2.2.2/gems/dap-0.1.21/bin/dap:123:in block (2 levels) in <top (required)>"
"/usr/local/rvm/gems/ruby-2.2.2/gems/dap-0.1.21/bin/dap:123:in collect"
"/usr/local/rvm/gems/ruby-2.2.2/gems/dap-0.1.21/bin/dap:123:in block in <top (required)>"
"/usr/local/rvm/gems/ruby-2.2.2/gems/dap-0.1.21/bin/dap:121:in each"
"/usr/local/rvm/gems/ruby-2.2.2/gems/dap-0.1.21/bin/dap:121:in <top (required)>"
"/usr/local/rvm/gems/ruby-2.2.2/bin/dap:23:in load"
"/usr/local/rvm/gems/ruby-2.2.2/bin/dap:23:in <main>"
"/usr/local/rvm/gems/ruby-2.2.2/bin/ruby_executable_hooks:15:in eval"
"/usr/local/rvm/gems/ruby-2.2.2/bin/ruby_executable_hooks:15:in <main>"
"Element:"
"0x84x00x00x00x00"
"Element hex:"
"[308400000000]"
```