### PR TITLE
More validation on gquic version

### DIFF
--- a/lib/dap/filter/gquic.rb
+++ b/lib/dap/filter/gquic.rb
@@ -28,7 +28,7 @@ module Dap
                  if version[0] == 'Q'
                     begin
                         # try to convert parse number from string
-                        print(Integer(version[1..3], 10))
+                        Integer(version[1..3], 10)
                         versions.push(version)
                     rescue
                     end

--- a/lib/dap/filter/gquic.rb
+++ b/lib/dap/filter/gquic.rb
@@ -24,14 +24,9 @@ module Dap
               step = 4
               while i < data.length 
                  version = data[i..i+4-1]
-                 # Versions start with the letter Q
-                 if version[0] == 'Q'
-                    begin
-                        # try to convert parse number from string
-                        Integer(version[1..3], 10)
-                        versions.push(version)
-                    rescue
-                    end
+                 # Versions start with the letter Q followed by number e.g. 001 - 043
+                 if version =~ /^Q\d{3}$/
+                     versions.push(version)
                  end
                  i = i + step
               end

--- a/lib/dap/filter/gquic.rb
+++ b/lib/dap/filter/gquic.rb
@@ -1,3 +1,5 @@
+# Documentation on what the different gquic values are
+# https://github.com/quicwg/base-drafts/wiki/QUIC-Versions
 module Dap
    module Filter
 
@@ -23,8 +25,13 @@ module Dap
               while i < data.length 
                  version = data[i..i+4-1]
                  # Versions start with the letter Q
-                 if data[i] == 'Q'
-                    versions.push(version)
+                 if version[0] == 'Q'
+                    begin
+                        # try to convert parse number from string
+                        print(Integer(version[1..3], 10))
+                        versions.push(version)
+                    rescue
+                    end
                  end
                  i = i + step
               end

--- a/spec/dap/filter/gquic_filter_spec.rb
+++ b/spec/dap/filter/gquic_filter_spec.rb
@@ -19,6 +19,13 @@ describe Dap::Filter::FilterDecodeGquicVersionsResult do
       end
     end
 
+    context 'testing gquic valid versions with invalid versions' do
+      let(:decode) { filter.decode("aaaaaaaaaQ044R043R039Q035")}
+      it 'returns an hash w/ versions as list of versions' do
+        expect(decode).to eq({"versions"=> ["Q044", "Q035"]})
+      end
+    end
+
     context 'testing valid string but not gquic versions' do
       let(:decode) { filter.decode("H044R043E039L035") }
       it 'returns nil' do

--- a/spec/dap/filter/gquic_filter_spec.rb
+++ b/spec/dap/filter/gquic_filter_spec.rb
@@ -5,8 +5,15 @@ describe Dap::Filter::FilterDecodeGquicVersionsResult do
 
     let(:filter) { described_class.new(['data']) }
 
-    context 'testing gquic valid input' do
+    context 'testing gquic valid input base64 encoded output from the real world' do
       let(:decode) { filter.decode(Base64.decode64("DQAAAAECAwQFUTA0NFEwNDNRMDM5UTAzNQ=="))}
+      it 'returns an hash w/ versions as list of versions' do
+        expect(decode).to eq({"versions"=> ["Q044","Q043","Q039","Q035"]})
+      end
+    end
+
+    context 'testing gquic valid input artifical example' do
+      let(:decode) { filter.decode("aaaaaaaaaQ044Q043Q039Q035")}
       it 'returns an hash w/ versions as list of versions' do
         expect(decode).to eq({"versions"=> ["Q044","Q043","Q039","Q035"]})
       end
@@ -14,6 +21,14 @@ describe Dap::Filter::FilterDecodeGquicVersionsResult do
 
     context 'testing valid string but not gquic versions' do
       let(:decode) { filter.decode("H044R043E039L035") }
+      it 'returns nil' do
+        expect(decode).to eq(nil)
+      end
+    end
+
+    # do not want ["Qy6j","Qrta","Ql3T","QkKf","QTUB"]
+    context 'testing valid string with Q in it but not gquic versions ' do
+      let(:decode) { filter.decode("aaaaaaaaaQy6jQrtaQl3TQkKfQTUB") }
       it 'returns nil' do
         expect(decode).to eq(nil)
       end


### PR DESCRIPTION
Looking at documentation here:

https://github.com/quicwg/base-drafts/wiki/QUIC-Versions

```
0x5130303[1-9] | Google | Google QUIC 01 - 09 (Q001 - Q009)
-- | -- | --
0x5130313[0-9] | Google | Google QUIC 10 - 19 (Q010 - Q019)
0x5130323[0-9] | Google | Google QUIC 20 - 29 (Q020 - Q029)
0x5130333[0-9] | Google | Google QUIC 30 - 39 (Q030 - Q039)
0x5130343[0-9] | Google | Google QUIC 40 - 49 (Q040 - Q049)
```
Google quic versions are the letter Q + a number (001 - 049) for now.

So apart from checking the Q its best to also check for the number as well.

Otherwise depending on input you can get  a version array such as this: 
```
["Qy6j","Qrta","Ql3T","QkKf","QTUB"]
```
Where we have a Q every four bytes, but is not a google quic version


Testing:

Added a few more tests to the spec. Tests ran with ```bundle exec rspec spec```