### PR TITLE
Add bats integration/functional tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "test/test_helper/bats-support"]
+	path = test/test_helper/bats-support
+	url = https://github.com/ztombol/bats-support
+[submodule "test/test_helper/bats-assert"]
+	path = test/test_helper/bats-assert
+	url = https://github.com/ztombol/bats-assert

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,13 @@ addons:
     - libgeoip-dev
     - libgeoip1
 script: bundle exec rspec spec
+
+services:
+  - docker
+
+before_install:
+  - docker build -t dap_bats -f Dockerfile.testing .
+
+script:
+  - docker build -t dap_bats -f Dockerfile.testing .
+  - docker run --rm --name dap_bats -it -e DAP_EXECUTABLE=dap dap_bats /bin/bash -c "find . -name \*.bats | grep -v test/test_helper/ | xargs -n1 bats"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,11 @@
-language: ruby
-cache: bundler
-sudo: false
-rvm:
-  - 2.4.5
-  - 2.5.3
-addons:
-  apt:
-    packages:
-    - libgeoip-dev
-    - libgeoip1
-script: bundle exec rspec spec
+language: generic
 
 services:
   - docker
 
 before_install:
-  - docker build -t dap_bats -f Dockerfile.testing .
+  - docker build -t dap_testing -f Dockerfile.testing .
 
 script:
-  - docker build -t dap_bats -f Dockerfile.testing .
-  - docker run --rm --name dap_bats -it -e DAP_EXECUTABLE=dap dap_bats /bin/bash -c "find . -name \*.bats | grep -v test/test_helper/ | xargs -n1 bats"
+  - docker build -t dap_testing -f Dockerfile.testing .
+  - docker run --rm --name dap_testing -it -e DAP_EXECUTABLE=dap dap_testing /bin/bash -l -c "rvm use 2.4.5 && gem build dap && gem install dap*.gem && bundle exec rspec spec && find /opt/bats_testing -name \*.bats | grep -v test/test_helper/ | xargs -n1 bats"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,23 @@ Finally, submit the PR.  Navigate to ```https://github.com/<your-github-username
 
 ### Testing
 
-When your PR is submitted, it will be automatically subjected to the full run of tests in [Travis](https://travis-ci.org/rapid7/dap/), however you are encourage to perform testing _before_ submitting the PR.  To do this, simply run `bundle exec rspec spec`.
+When your PR is submitted, it will be automatically subjected to the full run
+of tests in [Travis](https://travis-ci.org/rapid7/dap/), however you are
+encourage to perform testing _before_ submitting the PR.  There are two types of tests in place:
+run `bundle exec rspec spec`.  # Testing
+
+There are two testing frameworks in place.
+
+* Ruby rspec.  To run these tests outside of travis-ci:
+```
+bundle exec rspec spec
+```
+
+* [bats](https://github.com/sstephenson/bats) integration tests.  To run these tests outside of travis-ci:
+```
+docker build -t dap_bats -f Dockerfile.testing . && \
+docker run --rm --name dap_bats -it -e DAP_EXECUTABLE=dap dap_bats /bin/bash -c "find . -name \*.bats | grep -v test/test_helper/ | xargs -n1 bats"
+```
 
 ## Landing PRs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,15 +88,13 @@ run `bundle exec rspec spec`.  # Testing
 
 There are two testing frameworks in place.
 
-* Ruby rspec.  To run these tests outside of travis-ci:
-```
-bundle exec rspec spec
-```
+* Ruby `rspec`
+* [bats](https://github.com/sstephenson/bats) integration tests
 
-* [bats](https://github.com/sstephenson/bats) integration tests.  To run these tests outside of travis-ci:
+To run these outside of travis-ci, run:
 ```
-docker build -t dap_bats -f Dockerfile.testing . && \
-docker run --rm --name dap_bats -it -e DAP_EXECUTABLE=dap dap_bats /bin/bash -c "find . -name \*.bats | grep -v test/test_helper/ | xargs -n1 bats"
+docker build -t dap_testing -f Dockerfile.testing . && \
+docker run --rm --name dap_testing -it -e DAP_EXECUTABLE=dap dap_testing /bin/bash -l -c "rvm use 2.4.5 && gem build dap && gem install dap*.gem && bundle exec rspec spec && find /opt/bats_testing -name \*.bats | grep -v test/ test_helper/ | xargs -n1 bats"
 ```
 
 ## Landing PRs

--- a/Dockerfile.bats_testing
+++ b/Dockerfile.bats_testing
@@ -1,0 +1,32 @@
+FROM ubuntu:18.04
+
+ENV TEST_DIR /opt/bats_testing
+RUN apt-get update
+RUN apt-get install -y build-essential ca-certificates curl git libffi-dev libgeoip-dev libxml2-dev wget zlib1g-dev
+
+# install rvm and necessary ruby bits
+RUN command curl -sSL https://rvm.io/mpapis.asc | gpg --import -
+RUN command curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -
+RUN \curl -L https://get.rvm.io | bash -s stable
+RUN /bin/bash -l -c "rvm requirements"
+RUN /bin/bash -l -c "rvm install 2.4.5"
+RUN /bin/bash -l -c "rvm use 2.4.5 && gem update --system && gem install bundler"
+ADD Gemfile* $TEST_DIR/
+RUN /bin/bash -l -c "cd $TEST_DIR && rvm use 2.4.5 && bundle install"
+
+# install maxmind data
+RUN mkdir /var/lib/geoip
+WORKDIR /var/lib/geoip
+RUN wget -q https://github.com/maxmind/geoip-api-php/raw/master/tests/data/GeoIP.dat
+RUN wget -q https://github.com/maxmind/geoip-api-php/raw/master/tests/data/GeoIPCity.dat -O GeoLiteCity.dat
+RUN wget -q https://github.com/maxmind/geoip-api-php/raw/master/tests/data/GeoIPASNum.dat
+RUN wget -q https://github.com/maxmind/geoip-api-php/raw/master/tests/data/GeoIPOrg.dat -O geoip_org.dat
+
+# install bats
+RUN git clone https://github.com/sstephenson/bats.git && cd bats && ./install.sh /usr
+
+WORKDIR /opt/bats_testing
+COPY . .
+
+# find and run all .bats files
+ENTRYPOINT /bin/bash -l -c "rvm use 2.4.5 && gem build dap && gem install dap*.gem  && find /opt/bats_testing -name \*.bats | grep -v test/test_helper/ | xargs -n1 bats"

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 
 ENV TEST_DIR /opt/bats_testing
 RUN apt-get update
-RUN apt-get install -y build-essential ca-certificates curl git libffi-dev libgeoip-dev libxml2-dev wget zlib1g-dev
+RUN apt-get install -y build-essential ca-certificates curl git jq libffi-dev libgeoip-dev libxml2-dev wget zlib1g-dev
 
 # install rvm and necessary ruby bits
 RUN command curl -sSL https://rvm.io/mpapis.asc | gpg --import -

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -27,6 +27,3 @@ RUN git clone https://github.com/sstephenson/bats.git && cd bats && ./install.sh
 
 WORKDIR /opt/bats_testing
 COPY . .
-
-# find and run all .bats files
-ENTRYPOINT /bin/bash -l -c "rvm use 2.4.5 && gem build dap && gem install dap*.gem  && find /opt/bats_testing -name \*.bats | grep -v test/test_helper/ | xargs -n1 bats"

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -5,9 +5,9 @@ RUN apt-get update
 RUN apt-get install -y build-essential ca-certificates curl git jq libffi-dev libgeoip-dev libxml2-dev wget zlib1g-dev
 
 # install rvm and necessary ruby bits
-RUN command curl -sSL https://rvm.io/mpapis.asc | gpg --import -
-RUN command curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -
-RUN \curl -L https://get.rvm.io | bash -s stable
+RUN curl -sSL https://rvm.io/mpapis.asc | gpg --import -
+RUN curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -
+RUN curl -sSL https://get.rvm.io | bash -s stable
 RUN /bin/bash -l -c "rvm requirements"
 RUN /bin/bash -l -c "rvm install 2.4.5"
 RUN /bin/bash -l -c "rvm use 2.4.5 && gem update --system && gem install bundler"

--- a/test/filters.bats
+++ b/test/filters.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+
+load ./test_common
+
+@test "rename" {
+  run bash -c 'echo world | dap lines + rename line=hello + json'
+  assert_success
+  assert_output '{"hello":"world"}'
+}
+
+@test "not_exists" {
+  run bash -c "echo '{\"foo\":\"bar\"}' | dap json + not_exists foo + json"
+  assert_success
+  assert_output ''
+  run bash -c "echo '{\"bar\":\"bar\"}' | dap json + not_exists foo + json"
+  assert_success
+  assert_output '{"bar":"bar"}'
+}
+
+@test "split_comma" {
+  run bash -c "echo '{\"foo\":\"bar,baz\"}' | dap json + split_comma foo + json"
+  assert_success
+  assert_line --index 0 '{"foo":"bar,baz","foo.word":"bar"}'
+  assert_line --index 1 '{"foo":"bar,baz","foo.word":"baz"}'
+}
+
+@test "field_split_line" {
+  run bash -c "echo '{\"foo\":\"bar\nbaz\"}' | dap json + field_split_line foo + json"
+  assert_success
+  assert_output '{"foo":"bar\nbaz","foo.f1":"bar","foo.f2":"baz"}'
+}
+
+@test "not_empty" {
+  run bash -c "echo '{\"foo\":\"bar,baz\"}' | dap json + not_empty foo + json"
+  assert_success
+  assert_output '{"foo":"bar,baz"}'
+}
+
+@test "field_split_tab" {
+  run bash -c "echo '{\"foo\":\"bar\tbaz\"}' | dap json + field_split_tab foo + json"
+  assert_success
+  assert_output '{"foo":"bar\tbaz","foo.f1":"bar","foo.f2":"baz"}'
+}
+
+@test "truncate" {
+  run bash -c "echo '{\"foo\":\"bar\tbaz\"}' | dap json + truncate foo + json"
+  assert_success
+  assert_output '{"foo":""}'
+}
+
+@test "insert" {
+  run bash -c "echo '{\"foo\":\"bar\tbaz\"}' | dap json + insert a=b + json"
+  assert_success
+  assert_output '{"a":"b","foo":"bar\tbaz"}'
+}
+
+@test "field_split_array" {
+  run bash -c "echo '{\"foo\":[\"a\",2]}' | dap json + field_split_array foo + json"
+  assert_success
+  assert_output '{"foo":["a",2],"foo.f1":"a","foo.f2":2}'
+}
+
+@test "exists" {
+  run bash -c "echo '{\"foo\":\"bar\tbaz\"}' | dap json + exists a + json"
+  assert_success
+  assert_output ''
+  run bash -c "echo '{\"foo\":\"bar\tbaz\"}' | dap json + exists foo + json"
+  assert_success
+  assert_output '{"foo":"bar\tbaz"}'
+}
+
+@test "split_line" {
+  run bash -c "echo '{\"foo\":\"bar\nbaz\"}' | dap json + split_line foo + json"
+  assert_success
+  assert_line --index 0 '{"foo":"bar\nbaz","foo.line":"bar"}'
+  assert_line --index 1 '{"foo":"bar\nbaz","foo.line":"baz"}'
+}
+
+@test "select" {
+  run bash -c "echo '{\"foo\":\"bar\", \"baz\":\"qux\", \"a\":\"b\"}' | dap json + select foo + json"
+  assert_success
+  assert_output '{"foo":"bar"}'
+  run bash -c "echo '{\"foo\":\"bar\", \"baz\":\"qux\", \"a\":\"b\"}' | dap json + select foo baz + json"
+  assert_success
+  assert_output '{"baz":"qux","foo":"bar"}'
+}
+
+@test "remove" {
+  run bash -c "echo '{\"foo\":\"bar\", \"baz\":\"qux\", \"a\":\"b\"}' | dap json + remove foo baz + json"
+  assert_success
+  assert_output '{"a":"b"}'
+}
+
+@test "include" {
+  run bash -c "echo '{\"foo\":\"bar\", \"baz\":\"qux\", \"a\":\"b\"}' | dap json + include a=c + json"
+  assert_success
+  assert_output ''
+  run bash -c "echo '{\"foo\":\"bar\", \"baz\":\"qux\", \"a\":\"b\"}' | dap json + include a=b + json"
+  assert_success
+  assert_output '{"a":"b","baz":"qux","foo":"bar"}'
+}
+
+@test "transform" {
+  run bash -c "echo '{\"foo\":\"bar\"}' | dap json + transform foo=base64encode + json"
+  assert_success
+  assert_output '{"foo":"YmFy"}'
+}

--- a/test/filters.bats
+++ b/test/filters.bats
@@ -3,105 +3,128 @@
 load ./test_common
 
 @test "rename" {
-  run bash -c 'echo world | dap lines + rename line=hello + json'
+  run bash -c 'echo world | $DAP_EXECUTABLE lines + rename line=hello + json'
   assert_success
   assert_output '{"hello":"world"}'
 }
 
 @test "not_exists" {
-  run bash -c "echo '{\"foo\":\"bar\"}' | dap json + not_exists foo + json"
+  run bash -c "echo '{\"foo\":\"bar\"}' | $DAP_EXECUTABLE json + not_exists foo + json"
   assert_success
   assert_output ''
-  run bash -c "echo '{\"bar\":\"bar\"}' | dap json + not_exists foo + json"
+  run bash -c "echo '{\"bar\":\"bar\"}' | $DAP_EXECUTABLE json + not_exists foo + json"
   assert_success
   assert_output '{"bar":"bar"}'
 }
 
 @test "split_comma" {
-  run bash -c "echo '{\"foo\":\"bar,baz\"}' | dap json + split_comma foo + json"
+  run bash -c "echo '{\"foo\":\"bar,baz\"}' | $DAP_EXECUTABLE json + split_comma foo + json | jq -Sc ."
   assert_success
   assert_line --index 0 '{"foo":"bar,baz","foo.word":"bar"}'
   assert_line --index 1 '{"foo":"bar,baz","foo.word":"baz"}'
 }
 
 @test "field_split_line" {
-  run bash -c "echo '{\"foo\":\"bar\nbaz\"}' | dap json + field_split_line foo + json"
+  run bash -c "echo '{\"foo\":\"bar\nbaz\"}' | $DAP_EXECUTABLE json + field_split_line foo + json | jq -Sc ."
   assert_success
   assert_output '{"foo":"bar\nbaz","foo.f1":"bar","foo.f2":"baz"}'
 }
 
-@test "not_empty" {
-  run bash -c "echo '{\"foo\":\"bar,baz\"}' | dap json + not_empty foo + json"
+@test  "not_empty" {
+  # only exists in godap currently
+  skip
+  run bash -c "echo '{\"foo\":\"bar,baz\"}' | $DAP_EXECUTABLE json + not_empty foo + json | jq -Sc ."
   assert_success
   assert_output '{"foo":"bar,baz"}'
 }
 
 @test "field_split_tab" {
-  run bash -c "echo '{\"foo\":\"bar\tbaz\"}' | dap json + field_split_tab foo + json"
+  run bash -c "echo '{\"foo\":\"bar\tbaz\"}' | $DAP_EXECUTABLE json + field_split_tab foo + json | jq -Sc ."
   assert_success
   assert_output '{"foo":"bar\tbaz","foo.f1":"bar","foo.f2":"baz"}'
 }
 
 @test "truncate" {
-  run bash -c "echo '{\"foo\":\"bar\tbaz\"}' | dap json + truncate foo + json"
+  run bash -c "echo '{\"foo\":\"bar\tbaz\"}' | $DAP_EXECUTABLE json + truncate foo + json | jq -Sc ."
   assert_success
   assert_output '{"foo":""}'
 }
 
 @test "insert" {
-  run bash -c "echo '{\"foo\":\"bar\tbaz\"}' | dap json + insert a=b + json"
+  run bash -c "echo '{\"foo\":\"bar\tbaz\"}' | $DAP_EXECUTABLE json + insert a=b + json | jq -Sc ."
   assert_success
   assert_output '{"a":"b","foo":"bar\tbaz"}'
 }
 
 @test "field_split_array" {
-  run bash -c "echo '{\"foo\":[\"a\",2]}' | dap json + field_split_array foo + json"
+  run bash -c "echo '{\"foo\":[\"a\",2]}' | $DAP_EXECUTABLE json + field_split_array foo + json | jq -Sc ."
   assert_success
   assert_output '{"foo":["a",2],"foo.f1":"a","foo.f2":2}'
 }
 
 @test "exists" {
-  run bash -c "echo '{\"foo\":\"bar\tbaz\"}' | dap json + exists a + json"
+  run bash -c "echo '{\"foo\":\"bar\tbaz\"}' | $DAP_EXECUTABLE json + exists a + json | jq -Sc ."
   assert_success
   assert_output ''
-  run bash -c "echo '{\"foo\":\"bar\tbaz\"}' | dap json + exists foo + json"
+  run bash -c "echo '{\"foo\":\"bar\tbaz\"}' | $DAP_EXECUTABLE json + exists foo + json | jq -Sc ."
   assert_success
   assert_output '{"foo":"bar\tbaz"}'
 }
 
 @test "split_line" {
-  run bash -c "echo '{\"foo\":\"bar\nbaz\"}' | dap json + split_line foo + json"
+  run bash -c "echo '{\"foo\":\"bar\nbaz\"}' | $DAP_EXECUTABLE json + split_line foo + json | jq -Sc ."
   assert_success
   assert_line --index 0 '{"foo":"bar\nbaz","foo.line":"bar"}'
   assert_line --index 1 '{"foo":"bar\nbaz","foo.line":"baz"}'
 }
 
 @test "select" {
-  run bash -c "echo '{\"foo\":\"bar\", \"baz\":\"qux\", \"a\":\"b\"}' | dap json + select foo + json"
+  run bash -c "echo '{\"foo\":\"bar\", \"baz\":\"qux\", \"a\":\"b\"}' | $DAP_EXECUTABLE json + select foo + json | jq -Sc ."
   assert_success
   assert_output '{"foo":"bar"}'
-  run bash -c "echo '{\"foo\":\"bar\", \"baz\":\"qux\", \"a\":\"b\"}' | dap json + select foo baz + json"
+  run bash -c "echo '{\"foo\":\"bar\", \"baz\":\"qux\", \"a\":\"b\"}' | $DAP_EXECUTABLE json + select foo baz + json | jq -Sc ."
   assert_success
   assert_output '{"baz":"qux","foo":"bar"}'
 }
 
 @test "remove" {
-  run bash -c "echo '{\"foo\":\"bar\", \"baz\":\"qux\", \"a\":\"b\"}' | dap json + remove foo baz + json"
+  run bash -c "echo '{\"foo\":\"bar\", \"baz\":\"qux\", \"a\":\"b\"}' | $DAP_EXECUTABLE json + remove foo baz + json | jq -Sc ."
   assert_success
   assert_output '{"a":"b"}'
 }
 
 @test "include" {
-  run bash -c "echo '{\"foo\":\"bar\", \"baz\":\"qux\", \"a\":\"b\"}' | dap json + include a=c + json"
+  run bash -c "echo '{\"foo\":\"bar\", \"baz\":\"qux\", \"a\":\"b\"}' | $DAP_EXECUTABLE json + include a=c + json | jq -Sc ."
   assert_success
   assert_output ''
-  run bash -c "echo '{\"foo\":\"bar\", \"baz\":\"qux\", \"a\":\"b\"}' | dap json + include a=b + json"
+  run bash -c "echo '{\"foo\":\"bar\", \"baz\":\"qux\", \"a\":\"b\"}' | $DAP_EXECUTABLE json + include a=b + json | jq -Sc ."
   assert_success
   assert_output '{"a":"b","baz":"qux","foo":"bar"}'
 }
 
 @test "transform" {
-  run bash -c "echo '{\"foo\":\"bar\"}' | dap json + transform foo=base64encode + json"
+  run bash -c "echo '{\"foo\":\"bar\"}' | $DAP_EXECUTABLE json + transform foo=base64encode + json | jq -Sc ."
   assert_success
   assert_output '{"foo":"YmFy"}'
+}
+
+@test "recog_match" {
+  # currently differs from godap, need to figure out which is correct
+  skip
+  run bash -c "echo '9.8.2rc1-RedHat-9.8.2-0.62.rc1.el6_9.2' | $DAP_EXECUTABLE lines + recog line=dns.versionbind + json | jq -Sc ."
+  assert_success
+  assert_output '{"line":"9.8.2rc1-RedHat-9.8.2-0.62.rc1.el6_9.2","line.recog.os.cpe23":"cpe:/o:redhat:enterprise_linux:6","line.recog.os.family":"Linux","line.recog.os.product":"Enterprise Linux","line.recog.os.vendor":"Red Hat","line.recog.os.version":"6","line.recog.os.version.version":"9","line.recog.service.cpe23":"cpe:/a:isc:bind:9.8.2rc1","line.recog.service.family":"BIND","line.recog.service.product":"BIND","line.recog.service.vendor":"ISC","line.recog.service.version":"9.8.2rc1"}'
+}
+
+@test "recog_nomatch" {
+  run bash -c "echo 'should not match' | $DAP_EXECUTABLE lines + recog line=dns.versionbind + json | jq -Sc ."
+  assert_success
+  assert_output '{"line":"should not match"}'
+}
+
+@test "recog_invalid_arg" {
+  # currently fails in dap, passes in godap
+  skip
+  run bash -c "echo 'test' | $DAP_EXECUTABLE lines + recog + json"
+  assert_failure
 }

--- a/test/inputs.bats
+++ b/test/inputs.bats
@@ -1,0 +1,15 @@
+#!/usr/bin/env bats
+
+load ./test_common
+
+@test "reads json" {
+  run bash -c 'echo "{\"foo\": 1 }" | dap json + json'
+  assert_success
+  assert_output '{"foo":1}'
+}
+
+@test "reads lines" {
+  run bash -c 'echo hello world | dap lines + json'
+  assert_success
+  assert_output '{"line":"hello world"}'
+}

--- a/test/test_common.bash
+++ b/test/test_common.bash
@@ -1,0 +1,25 @@
+TEST_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+load "${TEST_DIR}/test_helper/bats-support/load.bash"
+load "${TEST_DIR}/test_helper/bats-assert/load.bash"
+
+function setup_workdir() {
+  WORK_DIR=`mktemp -d /tmp/output.XXXXXX`
+}
+
+function teardown_workdir() {
+  cd
+  if [ -z "${DISABLE_BATS_TEARDOWN}" ]; then
+    test -d $WORK_DIR && rm -Rf $WORK_DIR
+  fi
+}
+
+function setup() {
+  export PATH=/go/bin:/usr/local/go/bin:$PATH
+  setup_workdir
+}
+
+function teardown() {
+  teardown_workdir
+}
+

--- a/test/test_common.bash
+++ b/test/test_common.bash
@@ -15,7 +15,6 @@ function teardown_workdir() {
 }
 
 function setup() {
-  export PATH=/go/bin:/usr/local/go/bin:$PATH
   setup_workdir
 }
 


### PR DESCRIPTION
This adds `bats` functional/integration tests to `dap` which makes some testing easier, most notably testing that we can share between `dap` and [godap](https://github.com/rapid7/godap).  

