### PR TITLE
Require maxmind-db to support geoip2

### DIFF
--- a/dap.gemspec
+++ b/dap.gemspec
@@ -39,5 +39,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'bit-struct'
   s.add_runtime_dependency 'geoip-c'
   s.add_runtime_dependency 'recog'
+  s.add_runtime_dependency 'maxmind-db'
 
 end

--- a/lib/dap/version.rb
+++ b/lib/dap/version.rb
@@ -1,3 +1,3 @@
 module Dap
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end


### PR DESCRIPTION
I'm not quite sure how this passed testing but it blatantly fails when you try to run the 1.2.0 release outside of the `dap` directory and haven't manually installed `maxmind-db`:

```
$  dap --version     
/Users/jhart/.rbenv/versions/2.4.5/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:120:in `require': cannot load such file -- maxmind/db (LoadError)
```

This adds `maxmind-db` as a runtime requirement which means it will get installed when the `dap` gem is installed.

# Testing

I built locally and installed the new gem and confirmed that `dap --version` works again:

```
$  gem install dap-1.2.1.gem 
Fetching: maxmind-db-1.0.0.gem (100%)
Successfully installed maxmind-db-1.0.0
Successfully installed dap-1.2.1
Parsing documentation for maxmind-db-1.0.0
Installing ri documentation for maxmind-db-1.0.0
Parsing documentation for dap-1.2.1
Installing ri documentation for dap-1.2.1
Done installing documentation for maxmind-db, dap after 3 seconds
2 gems installed
$  dap --version                                                                                      
dap 1.2.0
```
