### PR TITLE
Only remove empties from geo_ip2 relevant fields, not entire doc

### DIFF
--- a/lib/dap/filter/geoip2.rb
+++ b/lib/dap/filter/geoip2.rb
@@ -238,10 +238,11 @@ class FilterGeoIP2LegacyCompat
       "isp.asn": "asn",
     }
 
+    ret = {}
     remap.each_pair do |geoip2,geoip|
       geoip2_key = "#{self.base_field}.geoip2.#{geoip2}"
       if doc.include?(geoip2_key)
-        doc["#{self.base_field}.#{geoip}"] = doc[geoip2_key]
+        ret["#{self.base_field}.#{geoip}"] = doc[geoip2_key]
       end
     end
 
@@ -256,7 +257,7 @@ class FilterGeoIP2LegacyCompat
     if doc.include?(anon_key)
       anon_value = doc[anon_key]
       if anon_value == "true"
-        doc["#{self.base_field}.country_code"] = "A1"
+        ret["#{self.base_field}.country_code"] = "A1"
       end
     end
 
@@ -264,7 +265,7 @@ class FilterGeoIP2LegacyCompat
     if doc.include?(satellite_key)
       satellite_value = doc[satellite_key]
       if satellite_value == "true"
-        doc["#{self.base_field}.country_code"] = "A1"
+        ret["#{self.base_field}.country_code"] = "A1"
       end
     end
 
@@ -273,7 +274,7 @@ class FilterGeoIP2LegacyCompat
     if doc.include?(metro_key)
       metro_value = doc[metro_key]
       if !metro_value.empty? && metro_value != "0"
-        doc["#{self.base_field}.dma_code"] = metro_value
+        ret["#{self.base_field}.dma_code"] = metro_value
       end
     end
 
@@ -284,12 +285,12 @@ class FilterGeoIP2LegacyCompat
     [ isp_org_key, isp_asn_org_key, asn_org_key ].each do |k|
       v = doc[k]
       if v && !v.empty?
-        doc["#{self.base_field}.org"] = v
+        ret["#{self.base_field}.org"] = v
         break
       end
     end
 
-    [ remove_empties(doc) ]
+    [ doc.merge(remove_empties(ret)) ]
   end
 end
 

--- a/lib/dap/version.rb
+++ b/lib/dap/version.rb
@@ -1,3 +1,3 @@
 module Dap
-  VERSION = "1.2.4"
+  VERSION = "1.2.5"
 end

--- a/test/filters.bats
+++ b/test/filters.bats
@@ -191,4 +191,8 @@ load ./test_common
   assert_line --index 2 '{"line":"2a02:d9c0::","line.country_code":"TR","line.country_name":"Turkey","line.latitude":"39.05901","line.longitude":"34.91155"}'
   # exists in ISP
   assert_line --index 3 '{"line":"2a01:1000::","line.asn":"AS5617","line.org":"Telekomunikacja Polska S.A."}'
+
+  run bash -c "echo '{\"ip\": \"4.2.2.1\", \"something_empty\": \"\", \"some_int\": 80}' | GEOIP2_CITY_DATABASE_PATH=test/test_data/geoip2/GeoIP2-City-Test.mmdb dap json + geo_ip2_city ip + geo_ip2_legacy_compat ip + match_remove ip. + json"
+  assert_success
+  assert_output '{"ip":"4.2.2.1","something_empty":"","some_int":80}'
 }


### PR DESCRIPTION
A side effect from #72.

With #72 you'd accidentally delete any empty fields from the document:

```
$  echo '{"ip": "4.2.2.1", "something_empty": ""}' | dap json + geo_ip2_city ip + geo_ip2_legacy_compat ip + match_remove ip. + json           
{"ip":"4.2.2.1"}
```

You'd also encounter exceptions for fields that don't support `empty?`:

```
$  echo '{"ip": "4.2.2.1", "something_empty": "", "some_int": 80}' | dap json + geo_ip2_city ip + geo_ip2_legacy_compat ip + match_remove ip. + json      
/Users/jhart/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/dap-1.2.4/lib/dap/filter/geoip2.rb:38:in `block in remove_empties': undefined method `empty?' for 80:Integer (NoMethodError)
        from /Users/jhart/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/dap-1.2.4/lib/dap/filter/geoip2.rb:37:in `each_pair'
        from /Users/jhart/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/dap-1.2.4/lib/dap/filter/geoip2.rb:37:in `remove_empties'
        from /Users/jhart/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/dap-1.2.4/lib/dap/filter/geoip2.rb:292:in `process'
        from /Users/jhart/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/dap-1.2.4/bin/dap:123:in `block (2 levels) in <top (required)>'
        from /Users/jhart/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/dap-1.2.4/bin/dap:123:in `collect'
        from /Users/jhart/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/dap-1.2.4/bin/dap:123:in `block in <top (required)>'
        from /Users/jhart/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/dap-1.2.4/bin/dap:121:in `each'
        from /Users/jhart/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/dap-1.2.4/bin/dap:121:in `<top (required)>'
        from /Users/jhart/.rbenv/versions/2.4.5/bin/dap:23:in `load'
        from /Users/jhart/.rbenv/versions/2.4.5/bin/dap:23:in `<main>'
```