### PR TITLE
Update geo_ip2* filters to properly handle invalid IPs

### DIFF
--- a/lib/dap/filter/geoip2.rb
+++ b/lib/dap/filter/geoip2.rb
@@ -33,6 +33,16 @@ module GeoIP2Library
     nil
   end
 
+  def get_maxmind_data(db, ip)
+    geo_hash = nil
+    begin
+      geo_hash = db.get(ip)
+    rescue IPAddr::InvalidAddressError
+    end
+
+    geo_hash
+  end
+
   def remove_empties(hash)
     hash.each_pair do |k,v|
       if v.empty?
@@ -78,8 +88,9 @@ class FilterGeoIP2City
     unless @@geo_city
       raise "No MaxMind GeoIP2::City data found"
     end
-    return unless (geo_hash = @@geo_city.get(ip))
+
     ret = defaults
+    return unless (geo_hash = get_maxmind_data(@@geo_city, ip))
 
     if geo_hash.include?("subdivisions")
       # handle countries that are divided into various subdivisions.  generally 1, sometimes 2
@@ -143,10 +154,9 @@ class FilterGeoIP2Asn
     unless @@geo_asn
       raise "No MaxMind GeoIP2::ASN data found"
     end
-    geo_hash = @@geo_asn.get(ip)
-    return unless geo_hash
 
     ret = {}
+    return unless (geo_hash = get_maxmind_data(@@geo_asn, ip))
 
     if geo_hash.include?("autonomous_system_number")
       ret["geoip2.asn.asn"] = "AS#{geo_hash["autonomous_system_number"]}"
@@ -174,10 +184,9 @@ class FilterGeoIP2Isp
     unless @@geo_isp
       raise "No MaxMind GeoIP2::ISP data found"
     end
-    geo_hash = @@geo_isp.get(ip)
-    return unless geo_hash
 
     ret = {}
+    return unless (geo_hash = get_maxmind_data(@@geo_isp, ip))
 
     if geo_hash.include?("autonomous_system_number")
       ret["geoip2.isp.asn"] = "AS#{geo_hash["autonomous_system_number"]}"

--- a/lib/dap/filter/geoip2.rb
+++ b/lib/dap/filter/geoip2.rb
@@ -34,13 +34,10 @@ module GeoIP2Library
   end
 
   def get_maxmind_data(db, ip)
-    geo_hash = nil
     begin
-      geo_hash = db.get(ip)
+      db.get(ip)
     rescue IPAddr::InvalidAddressError
     end
-
-    geo_hash
   end
 
   def remove_empties(hash)
@@ -90,7 +87,8 @@ class FilterGeoIP2City
     end
 
     ret = defaults
-    return unless (geo_hash = get_maxmind_data(@@geo_city, ip))
+    geo_hash = get_maxmind_data(@@geo_city, ip)
+    return unless geo_hash
 
     if geo_hash.include?("subdivisions")
       # handle countries that are divided into various subdivisions.  generally 1, sometimes 2
@@ -155,8 +153,9 @@ class FilterGeoIP2Asn
       raise "No MaxMind GeoIP2::ASN data found"
     end
 
+    geo_hash = get_maxmind_data(@@geo_asn, ip)
+    return unless geo_hash
     ret = {}
-    return unless (geo_hash = get_maxmind_data(@@geo_asn, ip))
 
     if geo_hash.include?("autonomous_system_number")
       ret["geoip2.asn.asn"] = "AS#{geo_hash["autonomous_system_number"]}"
@@ -185,8 +184,9 @@ class FilterGeoIP2Isp
       raise "No MaxMind GeoIP2::ISP data found"
     end
 
+    geo_hash = get_maxmind_data(@@geo_isp, ip)
+    return unless geo_hash
     ret = {}
-    return unless (geo_hash = get_maxmind_data(@@geo_isp, ip))
 
     if geo_hash.include?("autonomous_system_number")
       ret["geoip2.isp.asn"] = "AS#{geo_hash["autonomous_system_number"]}"

--- a/lib/dap/version.rb
+++ b/lib/dap/version.rb
@@ -1,3 +1,3 @@
 module Dap
-  VERSION = "1.2.5"
+  VERSION = "1.2.6"
 end

--- a/test/filters.bats
+++ b/test/filters.bats
@@ -160,6 +160,11 @@ load ./test_common
   run bash -c "echo 2a02:d9c0:: | GEOIP2_CITY_DATABASE_PATH=test/test_data/geoip2/GeoIP2-City-Test.mmdb $DAP_EXECUTABLE lines + geo_ip2_city line + json | jq -Sc -r ."
   assert_success
   assert_output '{"line":"2a02:d9c0::","line.geoip2.city.city.geoname_id":"0","line.geoip2.city.continent.code":"AS","line.geoip2.city.continent.geoname_id":"6255147","line.geoip2.city.continent.name":"Asia","line.geoip2.city.country.geoname_id":"298795","line.geoip2.city.country.is_in_european_union":"false","line.geoip2.city.country.iso_code":"TR","line.geoip2.city.country.name":"Turkey","line.geoip2.city.location.accuracy_radius":"100","line.geoip2.city.location.latitude":"39.05901","line.geoip2.city.location.longitude":"34.91155","line.geoip2.city.location.metro_code":"0","line.geoip2.city.location.time_zone":"Europe/Istanbul","line.geoip2.city.registered_country.geoname_id":"298795","line.geoip2.city.registered_country.is_in_european_union":"false","line.geoip2.city.registered_country.iso_code":"TR","line.geoip2.city.registered_country.name":"Turkey","line.geoip2.city.represented_country.geoname_id":"0","line.geoip2.city.represented_country.is_in_european_union":"false","line.geoip2.city.traits.is_anonymous_proxy":"false","line.geoip2.city.traits.is_satellite_provider":"false"}'
+
+  # test invalid IP
+  run bash -c "echo test | GEOIP2_CITY_DATABASE_PATH=test/test_data/geoip2/GeoIP2-City-Test.mmdb $DAP_EXECUTABLE lines + geo_ip2_city line + json | jq -Sc -r ."
+  assert_success
+  assert_output '{"line":"test"}'
 }
 
 @test "geo_ip2_asn" {
@@ -171,13 +176,20 @@ load ./test_common
   run bash -c "echo 2600:7000:: | GEOIP2_ASN_DATABASE_PATH=test/test_data/geoip2/GeoLite2-ASN-Test.mmdb $DAP_EXECUTABLE lines + geo_ip2_asn line + json | jq -Sc -r ."
   assert_success
   assert_output '{"line":"2600:7000::","line.geoip2.asn.asn":"AS6939","line.geoip2.asn.asn_org":"Hurricane Electric, Inc."}'
+
+  # test invalid IP
+  run bash -c "echo test | GEOIP2_ASN_DATABASE_PATH=test/test_data/geoip2/GeoLite2-ASN-Test.mmdb $DAP_EXECUTABLE lines + geo_ip2_asn line + json | jq -Sc -r ."
+  assert_success
+  assert_output '{"line":"test"}'
 }
 
 @test "geo_ip2_isp" {
-  run bash -c "echo -e '12.81.92.0\n2600:7000::' | GEOIP2_ISP_DATABASE_PATH=test/test_data/geoip2/GeoIP2-ISP-Test.mmdb $DAP_EXECUTABLE lines + geo_ip2_isp line + json | jq -Sc -r ."
+  run bash -c "echo -e '12.81.92.0\n2600:7000::\ntest' | GEOIP2_ISP_DATABASE_PATH=test/test_data/geoip2/GeoIP2-ISP-Test.mmdb $DAP_EXECUTABLE lines + geo_ip2_isp line + json | jq -Sc -r ."
   assert_line --index 0 '{"line":"12.81.92.0","line.geoip2.isp.asn":"AS7018","line.geoip2.isp.isp":"AT&T Services","line.geoip2.isp.org":"AT&T Services"}'
   # test IPv6
   assert_line --index 1 '{"line":"2600:7000::","line.geoip2.isp.asn":"AS6939","line.geoip2.isp.asn_org":"Hurricane Electric, Inc."}'
+  # test invalid IP
+  assert_line --index 2 '{"line":"test"}'
 }
 
 @test "geo_ip2_legacy_compat" {


### PR DESCRIPTION
Previously this would result in an exception:



```
$  echo '{"ip": "foo"}' | dap json + geo_ip2_city ip + json
/Users/jhart/.rbenv/versions/2.4.5/lib/ruby/2.4.0/ipaddr.rb:563:in `in6_addr': invalid address (IPAddr::InvalidAddressError)
	from /Users/jhart/.rbenv/versions/2.4.5/lib/ruby/2.4.0/ipaddr.rb:500:in `initialize'
	from /Users/jhart/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/maxmind-db-1.0.0/lib/maxmind/db.rb:137:in `new'
	from /Users/jhart/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/maxmind-db-1.0.0/lib/maxmind/db.rb:137:in `get'
	from /Users/jhart/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/dap-1.2.5/lib/dap/filter/geoip2.rb:81:in `decode'
	from /Users/jhart/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/dap-1.2.5/lib/dap/filter/base.rb:27:in `block in process'
	from /Users/jhart/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/dap-1.2.5/lib/dap/filter/base.rb:25:in `each_pair'
	from /Users/jhart/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/dap-1.2.5/lib/dap/filter/base.rb:25:in `process'
	from /Users/jhart/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/dap-1.2.5/bin/dap:123:in `block (2 levels) in <top (required)>'
	from /Users/jhart/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/dap-1.2.5/bin/dap:123:in `collect'
	from /Users/jhart/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/dap-1.2.5/bin/dap:123:in `block in <top (required)>'
	from /Users/jhart/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/dap-1.2.5/bin/dap:121:in `each'
	from /Users/jhart/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/dap-1.2.5/bin/dap:121:in `<top (required)>'
	from /Users/jhart/.rbenv/versions/2.4.5/bin/dap:23:in `load'
	from /Users/jhart/.rbenv/versions/2.4.5/bin/dap:23:in `<main>'
```

Now it simply skips this entry and returns it unmodified, which is how most of the other filters work.