### PR TITLE
Require Recog 2.3.21,  bump for release of dap 1.2.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 
 # Ignore geoip data file
 data/geoip.dat
+data/GeoLite2-ASN.mmdb
+data/GeoLite2-City.mmdb
+data/GeoLite2-Country.mmdb
 
 /pkg/
 

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -14,7 +14,7 @@ RUN /bin/bash -l -c "rvm requirements"
 RUN /bin/bash -l -c "rvm install 2.4.5"
 RUN /bin/bash -l -c "rvm use 2.4.5 && gem update --system && gem install bundler"
 ADD Gemfile* $TEST_DIR/
-RUN /bin/bash -l -c "cd $TEST_DIR && rvm use 2.4.5 && bundle install"
+RUN /bin/bash -l -c "cd $TEST_DIR && rvm use 2.4.5 && bundle update --bundler && bundle install"
 
 # install maxmind legacy data
 RUN mkdir /var/lib/geoip

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ENV TEST_DIR /opt/bats_testing
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'net-dns'
 gem 'bit-struct'
 gem 'geoip-c'
 gem 'maxmind-db', '~> 1.0.0'
-gem 'recog', '>=2.3.8'
+gem 'recog', '>=2.3.21'
 
 group :test do
   gem 'rspec', '~> 3.9.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
     minitest (5.14.2)
     multi_test (0.1.2)
     net-dns (0.9.0)
-    nokogiri (1.10.9)
+    nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     oj (3.10.6)
     protobuf-cucumber (3.10.8)
@@ -61,7 +61,7 @@ GEM
       middleware
       thor
       thread_safe
-    recog (2.3.8)
+    recog (2.3.21)
       nokogiri
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -95,7 +95,7 @@ DEPENDENCIES
   maxmind-db (~> 1.0.0)
   net-dns
   oj
-  recog (>= 2.3.8)
+  recog (>= 2.3.21)
   rspec (~> 3.9.0)
 
 BUNDLED WITH

--- a/lib/dap/version.rb
+++ b/lib/dap/version.rb
@@ -1,3 +1,3 @@
 module Dap
-  VERSION = "1.2.8"
+  VERSION = "1.2.9"
 end


### PR DESCRIPTION
This PR bumps the `recog` dependency version to 2.3.21 and prepares for the release of `dap` 1.2.9


## Testing
`rspec`

```shell
$ docker rmi dap_testing
$ docker build -t dap_testing -f Dockerfile.testing .



$ docker run --rm --name dap_testing -it -e DAP_EXECUTABLE=dap dap_testing /bin/bash -l -c "rvm use 2.4.5 && gem build dap && gem install dap*.gem && bundle update --bundler && bundle exec rspec spec && find /opt/bats_testing -name \*.bats | grep -v test/test_helper/ | xargs -n1 bats"


Using /usr/local/rvm/gems/ruby-2.4.5
WARNING:  licenses is empty, but is recommended.  Use a license identifier from
http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
WARNING:  open-ended dependency on rspec (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on cucumber (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on aruba (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on nokogiri (>= 0) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on oj (>= 0) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on htmlentities (>= 0) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on net-dns (>= 0) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on bit-struct (>= 0) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on geoip-c (>= 0) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on recog (>= 0) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on maxmind-db (>= 0) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  See https://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: dap
  Version: 1.2.9
  File: dap-1.2.9.gem
Successfully installed dap-1.2.9
Parsing documentation for dap-1.2.9
Installing ri documentation for dap-1.2.9
Done installing documentation for dap after 4 seconds
1 gem installed
Using concurrent-ruby 1.1.7
Using i18n 1.8.5
Using minitest 5.14.2
Using thread_safe 0.3.6
Using tzinfo 1.2.7
Using activesupport 5.2.4.4
Using childprocess 4.0.0
Using builder 3.2.4
Using middleware 0.1.0
Using thor 1.0.1
Using protobuf-cucumber 3.10.8
Using cucumber-messages 12.4.0
Using cucumber-gherkin 13.0.0
Using cucumber-tag-expressions 2.0.4
Using cucumber-core 7.0.0
Using cucumber-cucumber-expressions 10.3.0
Using cucumber-html-formatter 6.0.3
Using cucumber-wire 3.0.0
Using diff-lcs 1.3
Using multi_test 0.1.2
Using ffi 1.13.1
Using sys-uname 1.2.1
Using cucumber 4.0.1
Using rspec-support 3.9.4
Using rspec-expectations 3.9.3
Using aruba 0.6.2
Using bit-struct 0.16
Using bundler 2.2.25
Using geoip-c 0.9.1
Using htmlentities 4.3.4
Using maxmind-db 1.0.0
Using mini_portile2 2.4.0
Using net-dns 0.9.0
Using nokogiri 1.10.10
Using oj 3.10.6
Using recog 2.3.21
Using rspec-core 3.9.2
Using rspec-mocks 3.9.1
Using rspec 3.9.0
Warning: the lockfile is being updated to Bundler 2, after which you will be unable to return to Bundler 1.
Bundle updated!

Dap::Filter::FilterDecodeGquicVersionsResult
  .decode
    testing gquic valid input base64 encoded output from the real world
      returns an hash w/ versions as list of versions
    testing gquic valid input artifical example
      returns an hash w/ versions as list of versions
    testing gquic valid versions with invalid versions
      returns an hash w/ versions as list of versions
    testing valid string but not gquic versions
      returns nil
    testing valid string with Q in it but not gquic versions
      returns nil
    testing gquic empty string input
      returns nil
    testing gquic nil input
      returns nil

Dap::Filter::FilterDecodeHTTPReply
  .decode
    decoding non-HTTP response
      returns an empty hash
    decoding uncompressed response
      correctly sets status code
      correctly sets status message
      correctly sets body
      correctly extracts http_raw_headers
      extracts Date http header
      extracts Last-Modified http header
    decoding binary response
      correctly sets http_raw_body base64
    decoding gzip compressed response
      correctly decompresses body
    decoding valid chunked responses
      correctly dechunks body
      finds normal headers
      finds trailing headers
    decoding bogus chunked responses
Skipping impossibly large 255-byte #2 chunk, at offset 14/35
      reads the partial body
Skipping impossibly large 255-byte #2 chunk, at offset 14/35
      finds normal headers
    decoding truncated, chunked responses
Skipping impossibly large 6-byte #3 chunk, at offset 35/35
      reads the partial body
Skipping impossibly large 6-byte #3 chunk, at offset 35/35
      finds normal headers
    decoding responses that are missing the "reason phrase", an RFC anomaly
      decodes anyway

Dap::Filter::FilterHTMLLinks
  .process
    lowercase
      extracted the correct links
    uppercase
      extracted the correct links
    scattercase
      extracted the correct links
    repeated less than symbol
      extracted the correct links

Dap::Filter::FilterDecodeLdapSearchResult
  .decode
    testing full ldap response message
      returns Hash as expected
      returns expected value
    testing invalid ldap response message
      returns error message as expected

Dap::Filter::FilterCopy
  .process
    copy one json field to another
      copies and leaves the original field

Dap::Filter::FilterFlatten
  .process
    flatten nested json
      has new flattened nested document keys
    ignore unnested keys
      is the same as the original document

Dap::Filter::FilterExpand
  .process
    expand unnested json
      has new expanded keys
    ignore all but specified unnested json
      has new expanded keys
    ignore nested json
      is the same as the original document

Dap::Filter::FilterRenameSubkeyMatch
  .process
    with subkeys
      renames keys as expected
    without subkeys
      produces unchanged output without errors

Dap::Filter::FilterMatchRemove
  .process
    with similar keys
      removes the expected keys

Dap::Filter::FilterMatchSelect
  .process
    with similar keys
      selects the expected keys

Dap::Filter::FilterSelect
  .process
    with similar keys
      selects the expected keys

Dap::Filter::FilterMatchSelectKey
  .process
    with similar keys
      selects the expected keys

Dap::Filter::FilterMatchSelectValue
  .process
    with similar keys
      selects the expected keys

Dap::Filter::FilterTransform
  .process
    invalid transform
      fails
    reverse
      ASCII
        is reversed
      UTF-8
        is reversed
    int default
      valid int
        is the correct int
      invalid int
        is the correct int
    int different base
      is the correct int
    float
      valid float
        is the correct float
      invalid float
        is the correct float
    json
      valid json
        is the correct JSON
      invalid json
        raises on invalid JSON
    stripping
      lstrip
        lstripped
      rstrip
        rstripped
      strip
        stripped

Dap::Filter::FilterFieldReplace
  .process
    replaced correctly

Dap::Filter::FilterFieldReplaceAll
  .process
    replaced correctly

Dap::Filter::FilterFieldSplitPeriod
  .process
    splitting on period boundary
      splits correctly

Dap::Filter::FilterFieldSplitLine
  .process
    splitting on newline boundary
      splits correctly

Dap::Filter::FilterDecodeDNSVersionReply
  .decode
    parsing empty string
      returns an empty hash
    parsing a partial response
      returns an empty hash
    parsing TCP DNS response
      returns the correct version
    parsing UDP DNS response
      returns the correct version

Dap::Input::InputJSON
  .read_record
    decoding input json
      parses values starting with a colon (:) as a string

Dap::Proto::IPMI::Channel_Auth_Reply
  .valid?
    testing with valid rmcp version and message length
      returns true as expected
    testing with invalid data
      returns false as expected

Dap::Proto::LDAP
  .decode_elem_length
    testing lengths shorter than 128 bits
      returns a Fixnum
      returns value correctly
    testing lengths greater than 128 bits
      returns a Fixnum
      returns value correctly
    testing with 3 byte length
      returns a Fixnum
      returns value correctly
    testing invalid length
      returns nil as expected
  .split_messages
    testing full message
      returns Array as expected
      returns SearchResultEntry value as expected
      returns SearchResultDone value as expected
    testing invalid message
      returns Array as expected
    testing short message
      returns Array as expected
    testing message length greater than total data length
      returns Array as expected
      returns empty Array as expected
    testing empty ASN.1 Sequence
      returns Array as expected
      returns empty Array as expected
  .parse_ldapresult
    testing valid data
      returns Hash as expected
      returns results as expected
    testing invalid data
      returns Hash as expected
      returns empty Hash as expected
  .parse_messages
    testing SearchResultEntry
      returns Array as expected
      returns SearchResultEntry value as expected
    testing SearchResultDone
      returns Array as expected
      returns SearchResultDone value as expected
    testing SearchResultDone - edge case #1
      returns Array as expected
      returns operationsError as expected
    testing UnhandledTag
      returns Array as expected
      returns UnhandledTag value as expected
    testing empty ASN.1 Sequence
      returns Array as expected
      returns error value as expected

Dap::Utils::Misc
  .flatten_hash
    with mixed nested data
      flattens properly

Finished in 0.06304 seconds (files took 0.36185 seconds to load)
99 examples, 0 failures

1..25
ok 1 rename
ok 2 not_exists
ok 3 split_comma
ok 4 field_split_line
ok 5 # skip not_empty
ok 6 field_split_tab
ok 7 truncate
ok 8 insert
ok 9 field_split_array
ok 10 exists
ok 11 split_line
ok 12 select
ok 13 remove
ok 14 include
ok 15 transform
ok 16 recog_match
ok 17 recog_nomatch
ok 18 # skip recog_invalid_arg
ok 19 geo_ip yields valid fields
ok 20 geo_ip_org yields valid fields
ok 21 geo_ip_asn
ok 22 geo_ip2_city
ok 23 geo_ip2_asn
ok 24 geo_ip2_isp
ok 25 geo_ip2_legacy_compat
1..2
ok 1 reads json
ok 2 reads lines
```


```
Using /usr/local/rvm/gems/ruby-2.4.5
WARNING:  licenses is empty, but is recommended.  Use a license identifier from
http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
WARNING:  open-ended dependency on rspec (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on cucumber (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on aruba (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on nokogiri (>= 0) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on oj (>= 0) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on htmlentities (>= 0) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on net-dns (>= 0) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on bit-struct (>= 0) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on geoip-c (>= 0) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on recog (>= 0) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on maxmind-db (>= 0) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  See https://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: dap
  Version: 1.2.7
  File: dap-1.2.7.gem
Successfully installed dap-1.2.7
Parsing documentation for dap-1.2.7
Installing ri documentation for dap-1.2.7
Done installing documentation for dap after 4 seconds
1 gem installed

Dap::Filter::FilterDecodeGquicVersionsResult
  .decode
    testing gquic valid input base64 encoded output from the real world
      returns an hash w/ versions as list of versions
    testing gquic valid input artifical example
      returns an hash w/ versions as list of versions
    testing gquic valid versions with invalid versions
      returns an hash w/ versions as list of versions
    testing valid string but not gquic versions
      returns nil
    testing valid string with Q in it but not gquic versions
      returns nil
    testing gquic empty string input
      returns nil
    testing gquic nil input
      returns nil

Dap::Filter::FilterDecodeHTTPReply
  .decode
    decoding non-HTTP response
      returns an empty hash
    decoding uncompressed response
      correctly sets status code
      correctly sets status message
      correctly sets body
      correctly extracts http_raw_headers
      extracts Date http header
      extracts Last-Modified http header
    decoding binary response
      correctly sets http_raw_body base64
    decoding gzip compressed response
      correctly decompresses body
    decoding valid chunked responses
      correctly dechunks body
      finds normal headers
      finds trailing headers
    decoding bogus chunked responses
Skipping impossibly large 255-byte #2 chunk, at offset 14/35
      reads the partial body
Skipping impossibly large 255-byte #2 chunk, at offset 14/35
      finds normal headers
    decoding truncated, chunked responses
Skipping impossibly large 6-byte #3 chunk, at offset 35/35
      reads the partial body
Skipping impossibly large 6-byte #3 chunk, at offset 35/35
      finds normal headers
    decoding responses that are missing the "reason phrase", an RFC anomaly
      decodes anyway

Dap::Filter::FilterHTMLLinks
  .process
    lowercase
      extracted the correct links
    uppercase
      extracted the correct links
    scattercase
      extracted the correct links

Dap::Filter::FilterDecodeLdapSearchResult
  .decode
    testing full ldap response message
      returns Hash as expected
      returns expected value
    testing invalid ldap response message
      returns error message as expected

Dap::Filter::FilterCopy
  .process
    copy one json field to another
      copies and leaves the original field

Dap::Filter::FilterFlatten
  .process
    flatten nested json
      has new flattened nested document keys
    ignore unnested keys
      is the same as the original document

Dap::Filter::FilterExpand
  .process
    expand unnested json
      has new expanded keys
    ignore all but specified unnested json
      has new expanded keys
    ignore nested json
      is the same as the original document

Dap::Filter::FilterRenameSubkeyMatch
  .process
    with subkeys
      renames keys as expected
    without subkeys
      produces unchanged output without errors

Dap::Filter::FilterMatchRemove
  .process
    with similar keys
      removes the expected keys

Dap::Filter::FilterMatchSelect
  .process
    with similar keys
      selects the expected keys

Dap::Filter::FilterSelect
  .process
    with similar keys
      selects the expected keys

Dap::Filter::FilterMatchSelectKey
  .process
    with similar keys
      selects the expected keys

Dap::Filter::FilterMatchSelectValue
  .process
    with similar keys
      selects the expected keys

Dap::Filter::FilterTransform
  .process
    invalid transform
      fails
    reverse
      ASCII
        is reversed
      UTF-8
        is reversed
    int default
      valid int
        is the correct int
      invalid int
        is the correct int
    int different base
      is the correct int
    float
      valid float
        is the correct float
      invalid float
        is the correct float
    json
      valid json
        is the correct JSON
      invalid json
        raises on invalid JSON
    stripping
      lstrip
        lstripped
      rstrip
        rstripped
      strip
        stripped

Dap::Filter::FilterFieldReplace
  .process
    replaced correctly

Dap::Filter::FilterFieldReplaceAll
  .process
    replaced correctly

Dap::Filter::FilterFieldSplitPeriod
  .process
    splitting on period boundary
      splits correctly

Dap::Filter::FilterFieldSplitLine
  .process
    splitting on newline boundary
      splits correctly

Dap::Filter::FilterDecodeDNSVersionReply
  .decode
    parsing empty string
      returns an empty hash
    parsing a partial response
      returns an empty hash
    parsing TCP DNS response
      returns the correct version
    parsing UDP DNS response
      returns the correct version

Dap::Input::InputJSON
  .read_record
    decoding input json
      parses values starting with a colon (:) as a string

Dap::Proto::IPMI::Channel_Auth_Reply
  .valid?
    testing with valid rmcp version and message length
      returns true as expected
    testing with invalid data
      returns false as expected

Dap::Proto::LDAP
  .decode_elem_length
    testing lengths shorter than 128 bits
      returns a Fixnum
      returns value correctly
    testing lengths greater than 128 bits
      returns a Fixnum
      returns value correctly
    testing with 3 byte length
      returns a Fixnum
      returns value correctly
    testing invalid length
      returns nil as expected
  .split_messages
    testing full message
      returns Array as expected
      returns SearchResultEntry value as expected
      returns SearchResultDone value as expected
    testing invalid message
      returns Array as expected
    testing short message
      returns Array as expected
    testing message length greater than total data length
      returns Array as expected
      returns empty Array as expected
    testing empty ASN.1 Sequence
      returns Array as expected
      returns empty Array as expected
  .parse_ldapresult
    testing valid data
      returns Hash as expected
      returns results as expected
    testing invalid data
      returns Hash as expected
      returns empty Hash as expected
  .parse_messages
    testing SearchResultEntry
      returns Array as expected
      returns SearchResultEntry value as expected
    testing SearchResultDone
      returns Array as expected
      returns SearchResultDone value as expected
    testing SearchResultDone - edge case #1
      returns Array as expected
      returns operationsError as expected
    testing UnhandledTag
      returns Array as expected
      returns UnhandledTag value as expected
    testing empty ASN.1 Sequence
      returns Array as expected
      returns error value as expected

Dap::Utils::Misc
  .flatten_hash
    with mixed nested data
      flattens properly

Finished in 0.07631 seconds (files took 0.38588 seconds to load)
98 examples, 0 failures
```

