### PR TITLE
Unwrap nested ASN.1 elements in LDAP results (referral crashes JSON output)

### DIFF
--- a/lib/dap/proto/ldap.rb
+++ b/lib/dap/proto/ldap.rb
@@ -103,6 +103,84 @@ class LDAP
     messages
   end
 
+  # Maximum number of levels asn1_value will unwrap. Responses come from
+  # untrusted hosts and may nest arbitrarily deeply, so bound the recursion
+  # instead of risking stack exhaustion.
+  ASN1_MAX_DEPTH = 32
+
+  # Substituted for values nested beyond ASN1_MAX_DEPTH. Returned as a fresh
+  # String each time: every other value this parser yields is unfrozen, and
+  # filters such as `transform <field>=utf8encode` mutate values in place, so
+  # handing out a shared frozen object would raise FrozenError downstream.
+  ASN1_TOO_DEEP = "[truncated: ASN.1 nesting exceeds #{ASN1_MAX_DEPTH} levels]".freeze
+
+  #
+  # Recursively unwrap an ASN.1 value into JSON-serializable Ruby objects.
+  #
+  # Constructed elements decode to an Array of nested OpenSSL::ASN1 objects
+  # rather than to a String. A referral, for example, is a SEQUENCE OF LDAPURL
+  # (RFC 4511 - 4.1.10), so its value is an Array of OctetStrings. Primitives
+  # are not always Strings either: an INTEGER or ENUMERATED decodes to an
+  # OpenSSL::BN. The JSON output filter dumps with Oj in strict mode and raises
+  # on any of those, so reduce each value to a String, an Array, or a
+  # JSON-native scalar.
+  #
+  # @param value [Object] Decoded ASN.1 value, element, or Array of elements
+  # @param depth [Integer] Current recursion level
+  # @return [Object] String, JSON-native scalar, or Array of either
+  #
+  def self.asn1_value(value, depth = 0)
+    # Much the commonest case by far: a primitive value that is already a String
+    return value if value.is_a?(::String)
+    return ASN1_TOO_DEEP.dup if depth >= ASN1_MAX_DEPTH
+
+    case value
+    when ::Array
+      value.map { |element| asn1_value(element, depth + 1) }
+    when OpenSSL::ASN1::ASN1Data
+      asn1_value(value.value, depth + 1)
+    when ::Numeric, ::TrueClass, ::FalseClass, ::NilClass
+      value
+    else
+      # OpenSSL::BN and friends; keep the field a String rather than emit a
+      # type the JSON output filter cannot dump. +String guarantees the result
+      # is mutable, since callers may transform it in place.
+      +value.to_s
+    end
+  end
+
+  #
+  # Unwrap an ASN.1 value that represents a single LDAPString / LDAPDN.
+  #
+  # Most LDAP text fields are OCTET STRINGs, and BER permits those to be sent
+  # constructed, in which case the value decodes to an Array of segments that
+  # concatenate to form the string. Always returning a String also keeps values
+  # usable as JSON object keys, which Oj requires to be Strings.
+  #
+  # @param value [Object] Decoded ASN.1 value, element, or Array of elements
+  # @return [String] The value as a String
+  #
+  def self.asn1_string(value)
+    return value if value.is_a?(::String)
+
+    unwrapped = asn1_value(value)
+
+    case unwrapped
+    when ::String then unwrapped
+    when ::Array
+      # OpenSSL hands back every decoded string as ASCII-8BIT, so the segments
+      # of a constructed OCTET STRING concatenate cleanly. Force binary anyway:
+      # these are octets, and joining mixed encodings would raise
+      # Encoding::CompatibilityError.
+      unwrapped.flatten.map { |segment| segment.to_s.b }.join
+    else
+      # +String returns a mutable copy when to_s hands back a frozen literal,
+      # as TrueClass#to_s and NilClass#to_s do. Downstream filters such as
+      # `transform <field>=utf8encode` mutate values in place.
+      +unwrapped.to_s
+    end
+  end
+
   #
   # Parse an LDAPResult (not SearchResult) ASN.1 structure
   #   Reference:  https://tools.ietf.org/html/rfc4511#section-4.1.9
@@ -122,8 +200,8 @@ class LDAP
 
     # These are probably safe if the resultCode validates
     results['resultDesc'] = RESULT_DESC[ results['resultCode'] ] if results['resultCode']
-    results['resultMatchedDN'] = ldap_result.value[1].value if ldap_result.value[1] && ldap_result.value[1].value
-    results['resultdiagMessage'] = ldap_result.value[2].value if ldap_result.value[2] && ldap_result.value[2].value
+    results['resultMatchedDN'] = asn1_string(ldap_result.value[1].value) if ldap_result.value[1] && ldap_result.value[1].value
+    results['resultdiagMessage'] = asn1_string(ldap_result.value[2].value) if ldap_result.value[2] && ldap_result.value[2].value
 
     # Handle optional elements that may be returned by certain
     # LDAP application messages
@@ -133,13 +211,21 @@ class LDAP
 
       case element.tag
       when 3
-        results['referral'] = element.value
+        # Referral is a SEQUENCE OF LDAPURL (RFC 4511 - 4.1.10). Keep the list
+        # shape when the element is constructed, as it normally is, but reduce
+        # each URI to a String. A primitive tag 3 stays a bare String.
+        unwrapped = asn1_value(element.value)
+        results['referral'] = if unwrapped.is_a?(::Array)
+                                unwrapped.map { |uri| asn1_string(uri) }
+                              else
+                                asn1_string(unwrapped)
+                              end
       when 7
-        results['serverSaslCreds'] = element.value
+        results['serverSaslCreds'] = asn1_string(element.value)
       when 10
-        results['responseName'] = element.value
+        results['responseName'] = asn1_string(element.value)
       when 11
-        results['responseValue'] = element.value
+        results['responseValue'] = asn1_string(element.value)
       end
     end
 
@@ -176,7 +262,7 @@ class LDAP
       # SearchResultEntry found..
       result_type = 'SearchResultEntry'
       if data.value[1].value[0].tag == 4
-        results['objectName'] = data.value[1].value[0].value
+        results['objectName'] = asn1_string(data.value[1].value[0].value)
       end
 
       if data.value[1].value[1]
@@ -186,10 +272,10 @@ class LDAP
         data.value[1].value[1].each do |partial_attrib|
 
           value_array = []
-          attrib_type = partial_attrib.value[0].value
+          attrib_type = asn1_string(partial_attrib.value[0].value)
 
           partial_attrib.value[1].each do |part_attrib_value|
-            value_array.push(part_attrib_value.value)
+            value_array.push(asn1_string(part_attrib_value.value))
           end
 
           attrib_hash[attrib_type] = value_array
@@ -217,8 +303,8 @@ class LDAP
         # but placed at a higher level in the response, salvage what we can..
         results['resultCode'] = data.value[2].value.to_i if data.value[2].value
         results['resultDesc'] = RESULT_DESC[ results['resultCode'] ] if results['resultCode']
-        results['resultMatchedDN'] = data.value[3].value if data.value[3] && data.value[3].value
-        results['resultdiagMessage'] = data.value[4].value if data.value[4] && data.value[4].value
+        results['resultMatchedDN'] = asn1_string(data.value[3].value) if data.value[3] && data.value[3].value
+        results['resultdiagMessage'] = asn1_string(data.value[4].value) if data.value[4] && data.value[4].value
       end
 
     elsif data.value[1] && data.value[1].tag == 1

--- a/spec/dap/proto/ldap_proto_spec.rb
+++ b/spec/dap/proto/ldap_proto_spec.rb
@@ -140,6 +140,47 @@ describe Dap::Proto::LDAP do
       end
     end
 
+    context 'testing SearchResultDone containing a referral' do
+      # A referral is a SEQUENCE OF LDAPURL (RFC 4511 - 4.1.10), so the
+      # CONTEXT_SPECIFIC element is constructed and decodes to an Array of
+      # nested OctetStrings rather than to a String. Modelled on a response
+      # observed in the wild, with the host details replaced by documentation
+      # addresses; that server also returned success alongside the referral.
+      hex = ['3081ca0201076581c40a010004000400a381ba042e6c6461703a2f2f3139322e' \
+             '302e322e313a313338392f636e3d7265662c64633d6578616d706c652c64633d' \
+             '636f6d04306c6461703a2f2f3139322e302e322e313a31303338392f636e3d72' \
+             '6566322c64633d6578616d706c652c64633d636f6d041e6e6c6461703a2f2f31' \
+             '39322e302e322e313a3338392f636e3d6e6c64617004186c6461703a2f2f3132' \
+             '372e302e302e312f636e3d6c6f6f70041c6c646170733a2f2f3139322e302e32' \
+             '2e313a3633362f636e3d73736c']
+      data = OpenSSL::ASN1.decode(hex.pack('H*'))
+
+      let(:parse_ldapresult) { subject.parse_ldapresult(data.value[1]) }
+      it 'returns Hash as expected' do
+        expect(parse_ldapresult.class).to eq(::Hash)
+      end
+
+      it 'returns the referral URLs as Strings' do
+        test_val = {  'resultCode' => 0,
+                      'resultDesc' => 'success',
+                      'resultMatchedDN' => '',
+                      'resultdiagMessage' => '',
+                      'referral' => [
+                        'ldap://192.0.2.1:1389/cn=ref,dc=example,dc=com',
+                        'ldap://192.0.2.1:10389/cn=ref2,dc=example,dc=com',
+                        'nldap://192.0.2.1:389/cn=nldap',
+                        'ldap://127.0.0.1/cn=loop',
+                        'ldaps://192.0.2.1:636/cn=ssl'
+                      ]
+        }
+        expect(parse_ldapresult).to eq(test_val)
+      end
+
+      it 'returns values that can be serialized to JSON' do
+        expect { Oj.dump(parse_ldapresult, mode: :strict) }.to_not raise_error
+      end
+    end
+
     context 'testing invalid data' do
       hex = ['300702010765020400']
       data = OpenSSL::ASN1.decode(hex.pack('H*'))
@@ -152,6 +193,306 @@ describe Dap::Proto::LDAP do
       it 'returns empty Hash as expected' do
         test_val = {}
         expect(parse_ldapresult).to eq(test_val)
+      end
+    end
+
+  end
+
+  describe 'constructed OCTET STRING in text fields' do
+
+    # matchedDN sent as a constructed OCTET STRING. Every value the parser
+    # returns has to survive Oj strict mode, since the JSON output filter runs
+    # outside the rescue in FilterDecodeLdapSearchResult and an unserializable
+    # value therefore aborts the whole stream rather than one record.
+    context 'testing a constructed matchedDN' do
+      let(:parsed) do
+        done = OpenSSL::ASN1::ASN1Data.new(
+          [OpenSSL::ASN1::Enumerated.new(0),
+           OpenSSL::ASN1::ASN1Data.new([OpenSSL::ASN1::OctetString.new('dc=a'),
+                                        OpenSSL::ASN1::OctetString.new('dc=b')],
+                                       4, :UNIVERSAL),
+           OpenSSL::ASN1::OctetString.new('')], 5, :APPLICATION)
+        der = OpenSSL::ASN1::Sequence.new([OpenSSL::ASN1::Integer.new(7), done]).to_der
+        subject.parse_ldapresult(OpenSSL::ASN1.decode(der).value[1])
+      end
+
+      it 'returns matchedDN as a concatenated String' do
+        expect(parsed['resultMatchedDN']).to eq('dc=adc=b')
+      end
+
+      it 'returns a result that can be serialized to JSON' do
+        expect { Oj.dump(parsed, mode: :strict) }.to_not raise_error
+      end
+    end
+
+    context 'testing a constructed attribute type, used as a Hash key' do
+      let(:parsed) do
+        partial = OpenSSL::ASN1::Sequence.new([
+          OpenSSL::ASN1::ASN1Data.new([OpenSSL::ASN1::OctetString.new('object'),
+                                       OpenSSL::ASN1::OctetString.new('Class')],
+                                      4, :UNIVERSAL),
+          OpenSSL::ASN1::Set.new([OpenSSL::ASN1::OctetString.new('top')])])
+        entry = OpenSSL::ASN1::ASN1Data.new(
+          [OpenSSL::ASN1::OctetString.new('dc=example'),
+           OpenSSL::ASN1::Sequence.new([partial])], 4, :APPLICATION)
+        der = OpenSSL::ASN1::Sequence.new([OpenSSL::ASN1::Integer.new(7), entry]).to_der
+        subject.parse_message(OpenSSL::ASN1.decode(der)).last
+      end
+
+      it 'returns the attribute type as a String key' do
+        expect(parsed['PartialAttributes']).to eq({ 'objectClass' => ['top'] })
+      end
+
+      it 'returns a result that can be serialized to JSON' do
+        expect { Oj.dump(parsed, mode: :strict) }.to_not raise_error
+      end
+    end
+
+  end
+
+  describe '.asn1_value' do
+
+    context 'testing primitive values' do
+      it 'passes Strings through unchanged' do
+        expect(subject.asn1_value('ldap://192.0.2.1/')).to eq('ldap://192.0.2.1/')
+      end
+
+      it 'unwraps a primitive ASN.1 element to its String value' do
+        expect(subject.asn1_value(OpenSSL::ASN1::OctetString.new('abc'))).to eq('abc')
+      end
+    end
+
+    context 'testing values that are not JSON native' do
+      # A decoded INTEGER or ENUMERATED yields an OpenSSL::BN, which Oj cannot
+      # dump in strict mode any more than it can dump an OctetString. Note that
+      # these must be round-tripped through DER: an element built in Ruby holds
+      # the Integer it was given, whereas a decoded one holds a BN, and only the
+      # latter is what reaches the parser in practice.
+      let(:decoded_integer) do
+        OpenSSL::ASN1.decode(OpenSSL::ASN1::Integer.new(42).to_der)
+      end
+
+      it 'yields an OpenSSL::BN when decoded, which Oj strict mode rejects' do
+        expect(decoded_integer.value.class).to eq(OpenSSL::BN)
+        expect { Oj.dump({ 'v' => decoded_integer.value }, mode: :strict) }
+          .to raise_error(TypeError)
+      end
+
+      it 'coerces an OpenSSL::BN to a String' do
+        expect(subject.asn1_value(decoded_integer)).to eq('42')
+      end
+
+      it 'coerces values nested inside a constructed element' do
+        elem = OpenSSL::ASN1.decode(
+          OpenSSL::ASN1::ASN1Data.new([OpenSSL::ASN1::Integer.new(42)],
+                                      3, :CONTEXT_SPECIFIC).to_der)
+        expect(subject.asn1_value(elem.value)).to eq(['42'])
+        expect { Oj.dump(subject.asn1_value(elem.value), mode: :strict) }.to_not raise_error
+      end
+
+      # Every String this parser yields must be mutable: filters such as
+      # `transform <field>=utf8encode` call encode! on the value in place.
+      it 'returns a mutable String even when to_s yields a frozen one' do
+        frozen_to_s = Class.new { def to_s; 'frozen-result'.freeze; end }.new
+        expect(subject.asn1_value(frozen_to_s).frozen?).to be false
+        expect(subject.asn1_string(frozen_to_s).frozen?).to be false
+      end
+
+      it 'preserves scalars that are already JSON native' do
+        decoded_bool = OpenSSL::ASN1.decode(OpenSSL::ASN1::Boolean.new(true).to_der)
+        expect(subject.asn1_value(decoded_bool)).to eq(true)
+      end
+    end
+
+    context 'testing deeply nested elements' do
+      let(:deeply_nested) do
+        node = OpenSSL::ASN1::OctetString.new('x')
+        1000.times { node = OpenSSL::ASN1::Sequence.new([node]) }
+        node
+      end
+
+      it 'does not exhaust the stack' do
+        expect { subject.asn1_value(deeply_nested) }.to_not raise_error
+      end
+
+      it 'truncates beyond the depth limit and stays serializable' do
+        result = subject.asn1_value(deeply_nested)
+        expect(result.flatten).to eq([described_class::ASN1_TOO_DEEP])
+        expect { Oj.dump(result, mode: :strict) }.to_not raise_error
+      end
+
+      # Filters such as `transform <field>=utf8encode` call encode! on the value,
+      # which mutates in place, so a shared frozen marker would raise FrozenError.
+      it 'returns the marker unfrozen, like every other value' do
+        expect(subject.asn1_value(deeply_nested).flatten).to all(satisfy { |v| !v.frozen? })
+      end
+    end
+
+  end
+
+  # serverSaslCreds, responseName and responseValue are single-valued per
+  # RFC 4511, but each is an OCTET STRING or LDAPOID and so may arrive
+  # constructed, exactly as matchedDN may.
+  describe 'the optional single-valued CONTEXT_SPECIFIC fields' do
+    def self.ldap_message(app_tag, optional)
+      body = OpenSSL::ASN1::ASN1Data.new(
+        [OpenSSL::ASN1::Enumerated.new(0),
+         OpenSSL::ASN1::OctetString.new(''),
+         OpenSSL::ASN1::OctetString.new('')] + optional, app_tag, :APPLICATION)
+      OpenSSL::ASN1.decode(
+        OpenSSL::ASN1::Sequence.new([OpenSSL::ASN1::Integer.new(7), body]).to_der)
+    end
+
+    def self.split_octets(a, b, tag)
+      OpenSSL::ASN1::ASN1Data.new([OpenSSL::ASN1::OctetString.new(a),
+                                   OpenSSL::ASN1::OctetString.new(b)],
+                                  tag, :CONTEXT_SPECIFIC)
+    end
+
+    context 'testing primitive values' do
+      data = ldap_message(24, [OpenSSL::ASN1::ASN1Data.new('1.3.6.1', 10, :CONTEXT_SPECIFIC),
+                               OpenSSL::ASN1::ASN1Data.new('payload', 11, :CONTEXT_SPECIFIC)])
+      let(:parsed) { subject.parse_message(data).last }
+
+      it 'passes responseName and responseValue through unchanged' do
+        expect(parsed['responseName']).to eq('1.3.6.1')
+        expect(parsed['responseValue']).to eq('payload')
+      end
+    end
+
+    context 'testing constructed values' do
+      data = ldap_message(24, [split_octets('1.3.', '6.1', 10),
+                               split_octets('pay', 'load', 11)])
+      let(:parsed) { subject.parse_message(data).last }
+
+      it 'concatenates the segments' do
+        expect(parsed['responseName']).to eq('1.3.6.1')
+        expect(parsed['responseValue']).to eq('payload')
+      end
+
+      it 'returns a result that can be serialized to JSON' do
+        expect { Oj.dump(parsed, mode: :strict) }.to_not raise_error
+      end
+    end
+
+    context 'testing a constructed serverSaslCreds' do
+      data = ldap_message(1, [split_octets('cre', 'ds', 7)])
+      let(:parsed) { subject.parse_message(data).last }
+
+      it 'concatenates the segments and stays serializable' do
+        expect(parsed['serverSaslCreds']).to eq('creds')
+        expect { Oj.dump(parsed, mode: :strict) }.to_not raise_error
+      end
+    end
+  end
+
+  describe 'binary attribute values' do
+
+    # Sonar's LDAP data routinely carries binary attribute values such as
+    # objectSid and objectGUID. Those must survive byte for byte.
+    let(:sid) { "\x01\x05\x00\x00\x00\x00\x00\x05\x15\xff\xfe".b }
+
+    let(:parsed) do
+      partial = OpenSSL::ASN1::Sequence.new([
+        OpenSSL::ASN1::OctetString.new('objectSid'),
+        OpenSSL::ASN1::Set.new([OpenSSL::ASN1::OctetString.new(sid)])])
+      entry = OpenSSL::ASN1::ASN1Data.new(
+        [OpenSSL::ASN1::OctetString.new('dc=example'),
+         OpenSSL::ASN1::Sequence.new([partial])], 4, :APPLICATION)
+      der = OpenSSL::ASN1::Sequence.new([OpenSSL::ASN1::Integer.new(7), entry]).to_der
+      subject.parse_message(OpenSSL::ASN1.decode(der)).last
+    end
+
+    it 'preserves the bytes of a binary value exactly' do
+      expect(parsed['PartialAttributes']['objectSid']).to eq([sid])
+    end
+
+    it 'preserves the encoding of a binary value' do
+      expect(parsed['PartialAttributes']['objectSid'].first.encoding)
+        .to eq(::Encoding::ASCII_8BIT)
+    end
+
+    it 'returns the value unfrozen' do
+      expect(parsed['PartialAttributes']['objectSid'].first.frozen?).to be false
+    end
+
+  end
+
+  describe '.asn1_string' do
+
+    # BER permits an OCTET STRING to be sent constructed, in which case the
+    # segments concatenate to form the value.
+    let(:constructed) do
+      OpenSSL::ASN1.decode(
+        OpenSSL::ASN1::ASN1Data.new([OpenSSL::ASN1::OctetString.new('dc=exa'),
+                                     OpenSSL::ASN1::OctetString.new('mple')],
+                                    4, :UNIVERSAL).to_der)
+    end
+
+    it 'passes a primitive String value through' do
+      expect(subject.asn1_string(OpenSSL::ASN1::OctetString.new('dc=example').value))
+        .to eq('dc=example')
+    end
+
+    it 'concatenates the segments of a constructed OCTET STRING' do
+      expect(subject.asn1_string(constructed.value)).to eq('dc=example')
+    end
+
+    it 'always returns a String, so the value is usable as a JSON object key' do
+      decoded_int = OpenSSL::ASN1.decode(OpenSSL::ASN1::Integer.new(42).to_der)
+      expect(subject.asn1_string(decoded_int)).to eq('42')
+      expect { Oj.dump({ subject.asn1_string(constructed.value) => 1 }, mode: :strict) }
+        .to_not raise_error
+    end
+
+  end
+
+  # These two cases are the only ways this parser's output changed shape for
+  # input that already serialized successfully. Both arise when a field the RFC
+  # declares an LDAPString / LDAPDN arrives as some other type, and in both the
+  # field is now reported with the type it is declared to have. Pinned here so
+  # the change is explicit rather than incidental.
+  describe 'text fields that arrive with a non-String type' do
+
+    context 'testing a BOOLEAN where an LDAPDN is expected' do
+      # matchedDN sent as BOOLEAN true
+      hex = ['300a020107e10505000101ff']
+      let(:parsed) { subject.parse_message(OpenSSL::ASN1.decode(hex.pack('H*'))).last }
+
+      it 'reports the value as a String rather than a JSON boolean' do
+        expect(parsed['resultMatchedDN']).to eq('true')
+      end
+
+      # TrueClass#to_s returns a frozen literal, and filters such as
+      # `transform <field>=utf8encode` mutate values in place.
+      it 'returns that String unfrozen' do
+        expect(parsed['resultMatchedDN'].frozen?).to be false
+      end
+    end
+
+    context 'testing an empty constructed value where an LDAPDN is expected' do
+      # matchedDN sent as an empty SEQUENCE
+      hex = ['300a02010765050a012f3000']
+      let(:parsed) { subject.parse_message(OpenSSL::ASN1.decode(hex.pack('H*'))).last }
+
+      it 'reports the value as an empty String rather than an empty Array' do
+        expect(parsed['resultMatchedDN']).to eq('')
+      end
+    end
+
+    context 'testing a referral whose element is not an OCTET STRING' do
+      let(:parsed) do
+        referral = OpenSSL::ASN1::ASN1Data.new([OpenSSL::ASN1::Boolean.new(true)],
+                                               3, :CONTEXT_SPECIFIC)
+        done = OpenSSL::ASN1::ASN1Data.new(
+          [OpenSSL::ASN1::Enumerated.new(10), OpenSSL::ASN1::OctetString.new(''),
+           OpenSSL::ASN1::OctetString.new(''), referral], 5, :APPLICATION)
+        der = OpenSSL::ASN1::Sequence.new([OpenSSL::ASN1::Integer.new(7), done]).to_der
+        subject.parse_message(OpenSSL::ASN1.decode(der)).last
+      end
+
+      it 'keeps the list shape and reports each URI as a String' do
+        expect(parsed['referral']).to eq(['true'])
       end
     end
 


### PR DESCRIPTION
## Problem

`OutputJSON#write_record` dumps with `Oj.dump(..., mode: :strict)`, which raises on any value that is not a native JSON type. That dump happens **outside** the `rescue Exception` in `FilterDecodeLdapSearchResult`, so one unserializable value does not spoil a single record — it terminates `dap`:

```
lib/dap/output.rb:143:in `dump': Failed to dump OpenSSL::ASN1::OctetString
Object to JSON in strict mode. (TypeError)
```

`parse_ldapresult` and `parse_message` copied decoded ASN.1 values straight into the result Hash, and several of those are not Strings:

- **A referral is `SEQUENCE OF LDAPURL`** ([RFC 4511 §4.1.10](https://tools.ietf.org/html/rfc4511#section-4.1.10)), so the tag 3 element is *constructed* and its value is an `Array` of `OctetString`s. This is the case hit in the wild: in a Project Sonar `tcp_ldap_636` study, **one referral-returning host out of 22,482** aborted the processing stage after 22,075 records (internal ref: SNR-1383).
- **BER permits a constructed OCTET STRING**, so any LDAP text field can decode to an Array of segments. That reaches `matchedDN`, `diagnosticMessage`, `objectName`, and the attribute type — the last used as a **Hash key**, where Oj additionally requires a String specifically (`In :strict and :null mode all Hash keys must be Strings`).
- **A decoded `INTEGER`/`ENUMERATED` yields an `OpenSSL::BN`**, which Oj strict mode rejects just as it does an `OctetString`.

## Fix

Two helpers, applied at every such site:

- **`asn1_value`** recursively reduces a value to a String, an Array, or a JSON-native scalar. Used for `referral`, which is genuinely list shaped.
- **`asn1_string`** returns a String, concatenating the segments of a constructed OCTET STRING per BER (a split `dc=exa` + `mple` reads back as `dc=example`). Used for the single-valued text fields, for each referral URI, and for the attribute type.

Nesting depth is attacker-controlled and `OpenSSL::ASN1.decode` does not bound it — it decodes 5,000 levels happily — so `asn1_value` caps recursion at `ASN1_MAX_DEPTH` (32, against a legitimate depth of 1). Without the cap a deeply nested response raises `SystemStackError`; `filter/ldap.rb` would swallow that, but `parse_ldapresult`/`parse_message` are public API and other callers may not.

Every String returned is mutable. `TrueClass#to_s` and `NilClass#to_s` hand back frozen literals, the truncation marker is a frozen constant, and an arbitrary object's `to_s` may return a frozen String — but filters such as `transform <field>=utf8encode` call `encode!` on the value, which mutates in place and raises `FrozenError` on a frozen String. All three routes are closed and pinned by spec.

Segments are joined as binary. OpenSSL hands back every decoded string as `ASCII-8BIT`, so they concatenate cleanly today, but joining mixed encodings would raise `Encoding::CompatibilityError`, and these are octets regardless. Binary attribute values such as `objectSid` pass through byte for byte with their encoding and mutability intact.

`resultCode` is **deliberately** left as `value.to_i`. Coercing a malformed code would silently report `'success'`; raising instead surfaces an `Error` record for that response, which is the more honest outcome.

Reviewer note on the specs: an element *built* in Ruby holds the `Integer` you gave it, while a *decoded* one holds a `BN`. Only the decoded form reaches this parser, so the specs round-trip through DER.

## Output compatibility

I diffed this parser against `master` over **240,000 generated responses**, covering every ASN.1 string, time and OID type LDAP might plausibly carry (`OctetString`, constructed `OCTET STRING`, `UTF8String`, `IA5String`, `PrintableString`, `UTCTime`, `GeneralizedTime`, `ObjectId`, `BitString`, `Integer`, `Enumerated`, `Boolean`, `Null`), with half the corpus weighted toward binary payloads (an `objectSid`-shaped blob, invalid UTF-8, a BOM fragment, an all-256-byte string). For every input where master already produced valid output, I compared the JSON:

| | count |
| --- | --- |
| identical output | 238,706 |
| previously fatal, now serializes | 993 |
| **regressed (valid → crash)** | **0** |
| output changed shape | 301 |
| frozen Strings returned as values | **0** (master 0) |
| `Encoding::CompatibilityError` | **0** |

The changes fall into exactly two cases, with no residual "other" bucket, and the binary corpus produced no additional category — binary and invalid-UTF-8 values pass through byte-identically. Both occur only where a field the RFC declares an `LDAPString`/`LDAPDN` arrived as another type, and in both the field is now reported with the type it is declared to have:

| Case | count | master | this branch |
| --- | --- | --- | --- |
| empty constructed value | 299 | `"resultMatchedDN":[]` | `"resultMatchedDN":""` |
| BOOLEAN in a text field | 2 | `"resultMatchedDN":true` | `"resultMatchedDN":"true"` |

These keep the field monomorphic for typed downstream consumers, which is why I have taken them rather than preserved the old shape — but they *are* changes, so both are pinned by spec to make them reviewable rather than incidental. Please push back if you would rather these stayed as-is.

**Well-formed responses are unchanged**, confirmed byte for byte against the captured Active Directory response used by the autosonar `ldap` template's golden-file test.

## Verification

Run locally by building libgeoip 1.6.12 from source for `geoip-c`, on two Rubies.

- **rspec, Ruby 3.4.2 and Ruby 3.1.3** (the gemspec minimum): `master` 99 examples / 0 failures → this branch **130 / 0** (+31). Stable over 9 runs with `--order random` across both. The 3.1 run resolves a different dependency set (nokogiri 1.18.10, oj 3.17.6, recog 3.1.35), so the change is not tied to the locked versions.
- **This repo's bats integration suite: 27/27, identical on master and this branch.**
- **The consuming project's golden-file test passes identically.** Project Sonar's `ldap` template test runs a captured Active Directory response through the entire processing pipeline (geoip enrichment, IMS basic, IMS processed via `decode_ldap_search_result`) and compares the output exactly. Passes with master `dap` and with this branch over repeated runs, so real-world output is unchanged end to end. That template is the only consumer of `decode_ldap_search_result`.
- **The original production dataset, replayed in the production runtime.** The study that triggered this (22,482 records, including the one referral-returning host) was replayed inside the Sonar worker container on Ruby 3.1.4 with the real oj 3.17.3 / recog 3.0.3, using two copies of the installed gem differing only in `lib/dap/proto/ldap.rb`:

  | | stock dap 1.3.1 | this branch |
  | --- | --- | --- |
  | dap over the 22,482 records | exits 1 after **22,075** | exits 0, all **22,482** |
  | the 22,075 records stock did emit | — | **byte-for-byte identical** |
  | the full stage command (`pigz \| parallel \| ims_output.sh`) | fails; 22,259 records survive the pipe before it dies | `PIPESTATUS=0 0 0`, **22,482/22,482**, valid `COMPLETE` marker |
  | the referral record | dropped | present, fully decoded |
  | truncation markers in output | — | 0 |

  The byte-for-byte match over the 22,075 records stock managed is the strongest statement available that real-world output is unchanged. Note also that under `parallel` the crash costs the whole 10 MB block, not just the offending record.

- **Every affected site** driven through `FilterDecodeLdapSearchResult` with a constructed OCTET STRING — `referral`, referral-with-INTEGER, attribute value, `resultMatchedDN`, `resultdiagMessage`, `objectName`, attribute type (Hash key), salvaged matchedDN/diagMessage, `serverSaslCreds`, `responseName`, `responseValue` — all `TypeError` on stock, all clean here.
- **Depth and width:** referrals nested 10/100/1,000/5,000 deep and 5,000 URIs wide all parse and serialize; the truncation marker never fires on any real data tested. Master raises `TypeError` on the nested cases.
- **Differential invariants** held across every corpus, on both Rubies and on repeated fresh seeds: no input regressed, no frozen String is ever returned as a value, every Hash key is a String, and no `Encoding::CompatibilityError` occurs.
- **Spec efficacy:** the new specs were run against master's `lib` to confirm they fail there. 25 of them do; the rest are deliberate "must not change" guards (binary preservation, primitive pass-through).
- **Performance** on a realistic 22-attribute AD record, 20,000 decode+dump cycles, 6 interleaved runs each: medians 1.782s master vs 1.861s here, ranges fully overlapping — within measurement noise. An earlier revision was reproducibly ~25% slower; a fast path for the common already-a-String case removed that.

All consumers of this file were checked: `lib/dap/filter/ldap.rb` is the only in-gem caller, its spec asserts exact String output and passes unchanged, and no bats test touches LDAP.

## Two pre-existing issues noticed while setting up (not addressed here)

1. **`Gemfile.lock` is unsatisfiable on the minimum supported Ruby.** The gemspec and Gemfile allow `>= 3.1`, but the lock pins `nokogiri 1.19.4`, which requires `>= 3.2`.
2. **`lib/dap/input/csv.rb` requires `csv`, a bundled gem since Ruby 3.4**, so it is not on the bundler path and `require 'dap'` fails outright on 3.4 until `csv` is declared. I added it locally to run the suite; it is deliberately **not** part of this PR.

Happy to send either as a separate PR. No version bump here, since releases look to be separate "Bump for release" commits.





